### PR TITLE
fix(tooling): let each machine point the browser MCP at its own binary

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
       "command": "npx",
       "args": [
         "chrome-devtools-mcp@latest",
-        "--executable-path=/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+        "--executable-path=${NEXUS_BROWSER_PATH:-/Applications/Brave Browser.app/Contents/MacOS/Brave Browser}"
       ]
     },
     "nexus-docs-mcp": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,29 @@ The rule that mandates querying it lives in [`.claude/rules/docs-mcp.md`](.claud
 
 ---
 
+## Browser MCP (chrome-devtools)
+
+`.mcp.json` also wires up `chrome-devtools-mcp`, which drives a real browser so
+Claude Code can screenshot and inspect a running app (see
+[`ui-audit`](.agents/skills/ui-audit-guide/SKILL.md)).
+
+It defaults to Brave at the macOS install path. On Linux or Windows, point
+`NEXUS_BROWSER_PATH` at your own Chromium-family binary — in your gitignored
+`.claude/settings.local.json`, so the shared config stays untouched:
+
+```json
+{
+  "env": {
+    "NEXUS_BROWSER_PATH": "C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe"
+  }
+}
+```
+
+Use forward slashes; the value is a JSON string, so backslashes would need
+escaping. Restart Claude Code (or `/mcp` → reconnect) to pick up the change.
+
+---
+
 ## Releasing
 
 Releases are driven by [changesets](https://github.com/changesets/changesets) and the [`Release`](.github/workflows/release.yml) workflow. Only the two runtime packages publish to npm; everything else is either internal or copy/own.


### PR DESCRIPTION
## Summary

- `.mcp.json` pinned `chrome-devtools-mcp` to `/Applications/Brave Browser.app/...`, so every browser tool call failed on Linux and Windows with `Browser was not found at the configured executablePath`. The path now reads `${NEXUS_BROWSER_PATH:-<the macOS path>}`, so macOS contributors see no change and everyone else overrides it from their gitignored `.claude/settings.local.json`.
- `CONTRIBUTING.md` documents the override next to the existing docs-MCP setup.

## GitHub Issue

Closes #684

## Test Plan

- [x] Drove the server over stdio with the Windows Brave path (`C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe`): `initialize` returns `chrome_devtools 1.8.0` and `new_page` opens the target URL. Before the fix the same call returned `Browser was not found at the configured executablePath`.
- [x] Used the now-working server to complete the browser verification that was missing from #683 — loaded the built docs, measured token colours in both themes, and captured light/dark screenshots.
- [x] `.mcp.json` and `.claude/settings.local.json` both parse as JSON.
- [x] Default unchanged for macOS: with `NEXUS_BROWSER_PATH` unset the expansion yields the original Brave path byte-for-byte.

## Notes

The documented value uses forward slashes. A Windows path with backslashes is legal JSON only when escaped (`C:\Program Files\...`), and an unescaped one silently produces a broken string — forward slashes avoid the trap and Node accepts them.

The other MCP server in `.mcp.json`, `nexus-docs-mcp`, is still unreachable on this machine, but that is not a config bug: it needs Docker (`make up`), which is not installed here. No change made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)