### PR TITLE
feat(docs): add a copy button to every code block

### DIFF
--- a/apps/console/src/lib/rhf-field.tsx
+++ b/apps/console/src/lib/rhf-field.tsx
@@ -8,7 +8,8 @@ import {
   useFormState,
 } from 'react-hook-form';
 
-import { cn, Label } from '@nexus_ds/react';
+import { Label } from '@nexus_ds/react';
+import { cn } from '@nexus_ds/react/utils';
 
 type RhfFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,

--- a/apps/console/src/modules/design-system/flows-route.tsx
+++ b/apps/console/src/modules/design-system/flows-route.tsx
@@ -5,7 +5,6 @@ import {
   AlertDescription,
   Badge,
   Button,
-  cn,
   EmptyState,
   EmptyStateDescription,
   EmptyStateHeader,
@@ -13,6 +12,7 @@ import {
   EmptyStateTitle,
   toast,
 } from '@nexus_ds/react';
+import { cn } from '@nexus_ds/react/utils';
 import { IconLayoutDashboard } from '@tabler/icons-react';
 import { Link } from '@tanstack/react-router';
 import type { ColumnDef } from '@tanstack/react-table';

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -228,7 +228,7 @@ describe('CodeBlock', () => {
   });
 
   it('gives the scroll container a tab stop a caller cannot remove', () => {
-    // The props type omits `tabIndex`, but a rehype plugin can still inject one
+    // The props type omits `tabIndex`, but an MDX plugin can still inject one
     // at runtime — the guard below the spread is what has to hold there.
     const injected: object = { tabIndex: -1 };
     const { container } = render(

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -90,6 +90,69 @@ describe('CodeBlock', () => {
     expect(copy.dataset.copyStatus).toBe('idle');
   });
 
+  it('restarts the reset window and re-announces on a repeat copy', async () => {
+    const copy = renderBlock();
+    const region = screen.getByRole('status');
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+    const firstAnnouncement = region.firstElementChild;
+
+    act(() => {
+      vi.advanceTimersByTime(1900);
+    });
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    // The first click's timer would have fired 100ms from here.
+    act(() => {
+      vi.advanceTimersByTime(1900);
+    });
+    expect(copy.dataset.copyStatus).toBe('copied');
+    expect(region.firstElementChild).not.toBe(firstAnnouncement);
+    expect(region.textContent).toBe('Code copied to clipboard');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(copy.dataset.copyStatus).toBe('idle');
+  });
+
+  it('reports a failure when the clipboard API is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    const copy = renderBlock();
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(screen.getByRole('status').textContent).toBe('Could not copy code');
+    expect(copy.dataset.copyStatus).toBe('failed');
+  });
+
+  it('reports a failure rather than a silent no-op for an empty block', async () => {
+    render(
+      <CodeBlock>
+        <code />
+      </CodeBlock>
+    );
+    const copy = screen.getByRole('button', { name: 'Copy code' });
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(screen.getByRole('status').textContent).toBe('Could not copy code');
+    expect(copy.dataset.copyStatus).toBe('failed');
+  });
+
   it('exposes the control as a focusable native button', () => {
     const copy = renderBlock();
 

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -77,8 +77,6 @@ describe('CodeBlock', () => {
     });
 
     expect(copy.dataset.copyStatus).toBe('idle');
-    // The block restores its own icon; the provider clears the region it owns,
-    // in place, so emptying it is not itself read out.
     expect(screen.getByRole('status').textContent).toBe('');
     expect(screen.getByRole('status').firstElementChild).toBe(announcement);
   });

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -57,7 +57,7 @@ describe('CodeBlock', () => {
     expect(writeText.mock.calls[0]![0]).not.toMatch(/copy/i);
   });
 
-  it('announces the confirmation, then resets it', async () => {
+  it('announces the confirmation, then returns the control to idle', async () => {
     const copy = renderBlock();
 
     expect(screen.getByRole('status').textContent).toBe('');
@@ -70,13 +70,17 @@ describe('CodeBlock', () => {
       'Code copied to clipboard'
     );
     expect(copy.dataset.copyStatus).toBe('copied');
+    const announcement = screen.getByRole('status').firstElementChild;
 
     act(() => {
       vi.advanceTimersByTime(2000);
     });
 
-    expect(screen.getByRole('status').textContent).toBe('');
     expect(copy.dataset.copyStatus).toBe('idle');
+    // The block restores its own icon; the provider clears the region it owns,
+    // in place, so emptying it is not itself read out.
+    expect(screen.getByRole('status').textContent).toBe('');
+    expect(screen.getByRole('status').firstElementChild).toBe(announcement);
   });
 
   it('announces a failed write instead of leaving a silent no-op', async () => {
@@ -184,6 +188,68 @@ describe('CodeBlock', () => {
       'Code copied to clipboard'
     );
     expect(controls[0]!.dataset.copyStatus).toBe('idle');
+  });
+
+  it("leaves another block's confirmation in the shared region on reset", async () => {
+    render(
+      <CopyAnnouncerProvider>
+        <CodeBlock>
+          <code>{SNIPPET}</code>
+        </CodeBlock>
+        <CodeBlock>
+          <code>{'const x = 1;\n'}</code>
+        </CodeBlock>
+      </CopyAnnouncerProvider>
+    );
+    const controls = screen.getAllByRole('button', { name: 'Copy code' });
+    const region = screen.getByRole('status');
+
+    await act(async () => {
+      fireEvent.click(controls[0]!);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      fireEvent.click(controls[1]!);
+    });
+    // Both blocks announce the same words, so identity — not text — is what
+    // separates "left alone" from "cleared" and from "announced again".
+    const announcement = region.firstElementChild;
+
+    // The first block's 2s reset lands here, a second after the other block
+    // announced. It must return only its own icon to idle.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(controls[0]!.dataset.copyStatus).toBe('idle');
+    expect(controls[1]!.dataset.copyStatus).toBe('copied');
+    expect(region.firstElementChild).toBe(announcement);
+    expect(region.textContent).toBe('Code copied to clipboard');
+  });
+
+  it('gives the scroll container a tab stop a caller cannot remove', () => {
+    // The props type omits `tabIndex`, but a rehype plugin can still inject one
+    // at runtime — the guard below the spread is what has to hold there.
+    const injected: object = { tabIndex: -1 };
+    const { container } = render(
+      <CopyAnnouncerProvider>
+        <CodeBlock>
+          <code>{SNIPPET}</code>
+        </CodeBlock>
+        <CodeBlock {...injected}>
+          <code>{SNIPPET}</code>
+        </CodeBlock>
+      </CopyAnnouncerProvider>
+    );
+    const [own, overridden] = Array.from(container.querySelectorAll('pre'));
+
+    expect(own!.tabIndex).toBe(0);
+    expect(overridden!.tabIndex).toBe(0);
+
+    own!.focus();
+    expect(document.activeElement).toBe(own);
   });
 
   it('exposes the control as a focusable native button', () => {

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -6,8 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodeBlock } from './CodeBlock';
 import { CopyAnnouncerProvider } from './CopyAnnouncer';
 
-// Shaped like a real block from content/getting-started/install.mdx: the import
-// line is what a trimmed excerpt would drop, and the fence leaves a trailing \n.
+// A real block shape: an import line, and the fence's trailing newline.
 const SNIPPET = `import { Button } from '@nexus_ds/react';
 
 export function Example() {
@@ -17,8 +16,7 @@ export function Example() {
 
 const writeText = vi.fn<(text: string) => Promise<void>>();
 
-// The live region is shared page-wide, so a block is only testable inside the
-// provider that owns it — the same wiring `app/layout.tsx` supplies.
+// The live region lives in the provider, so a block is only testable inside one.
 function renderInDocs(block: React.ReactNode) {
   render(<CopyAnnouncerProvider>{block}</CopyAnnouncerProvider>);
   return screen.getByRole('button', { name: 'Copy code' });
@@ -211,12 +209,10 @@ describe('CodeBlock', () => {
     await act(async () => {
       fireEvent.click(controls[1]!);
     });
-    // Both blocks announce the same words, so identity — not text — is what
-    // separates "left alone" from "cleared" and from "announced again".
+    // Both blocks announce the same words, so identity separates the cases.
     const announcement = region.firstElementChild;
 
-    // The first block's 2s reset lands here, a second after the other block
-    // announced. It must return only its own icon to idle.
+    // The first block's 2s reset lands here, after the other block announced.
     act(() => {
       vi.advanceTimersByTime(1000);
     });
@@ -228,8 +224,7 @@ describe('CodeBlock', () => {
   });
 
   it('gives the scroll container a tab stop a caller cannot remove', () => {
-    // The props type omits `tabIndex`, but an MDX plugin can still inject one
-    // at runtime — the guard below the spread is what has to hold there.
+    // The props type omits `tabIndex`, but an MDX plugin can still inject one.
     const injected: object = { tabIndex: -1 };
     const { container } = render(
       <CopyAnnouncerProvider>

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CodeBlock } from './CodeBlock';
+import { CopyAnnouncerProvider } from './CopyAnnouncer';
 
 // Shaped like a real block from content/getting-started/install.mdx: the import
 // line is what a trimmed excerpt would drop, and the fence leaves a trailing \n.
@@ -16,13 +17,19 @@ export function Example() {
 
 const writeText = vi.fn<(text: string) => Promise<void>>();
 
+// The live region is shared page-wide, so a block is only testable inside the
+// provider that owns it — the same wiring `app/layout.tsx` supplies.
+function renderInDocs(block: React.ReactNode) {
+  render(<CopyAnnouncerProvider>{block}</CopyAnnouncerProvider>);
+  return screen.getByRole('button', { name: 'Copy code' });
+}
+
 function renderBlock() {
-  render(
+  return renderInDocs(
     <CodeBlock>
       <code className="language-tsx">{SNIPPET}</code>
     </CodeBlock>
   );
-  return screen.getByRole('button', { name: 'Copy code' });
 }
 
 describe('CodeBlock', () => {
@@ -137,12 +144,11 @@ describe('CodeBlock', () => {
   });
 
   it('reports a failure rather than a silent no-op for an empty block', async () => {
-    render(
+    const copy = renderInDocs(
       <CodeBlock>
         <code />
       </CodeBlock>
     );
-    const copy = screen.getByRole('button', { name: 'Copy code' });
 
     await act(async () => {
       fireEvent.click(copy);
@@ -151,6 +157,33 @@ describe('CodeBlock', () => {
     expect(writeText).not.toHaveBeenCalled();
     expect(screen.getByRole('status').textContent).toBe('Could not copy code');
     expect(copy.dataset.copyStatus).toBe('failed');
+  });
+
+  it('shares one live region across every block on the page', async () => {
+    render(
+      <CopyAnnouncerProvider>
+        <CodeBlock>
+          <code>{SNIPPET}</code>
+        </CodeBlock>
+        <CodeBlock>
+          <code>{'const x = 1;\n'}</code>
+        </CodeBlock>
+      </CopyAnnouncerProvider>
+    );
+    const controls = screen.getAllByRole('button', { name: 'Copy code' });
+
+    expect(controls).toHaveLength(2);
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+
+    await act(async () => {
+      fireEvent.click(controls[1]!);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('const x = 1;\n');
+    expect(screen.getByRole('status').textContent).toBe(
+      'Code copied to clipboard'
+    );
+    expect(controls[0]!.dataset.copyStatus).toBe('idle');
   });
 
   it('exposes the control as a focusable native button', () => {

--- a/apps/docs/app/_components/CodeBlock.test.tsx
+++ b/apps/docs/app/_components/CodeBlock.test.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CodeBlock } from './CodeBlock';
+
+// Shaped like a real block from content/getting-started/install.mdx: the import
+// line is what a trimmed excerpt would drop, and the fence leaves a trailing \n.
+const SNIPPET = `import { Button } from '@nexus_ds/react';
+
+export function Example() {
+  return <Button>Save</Button>;
+}
+`;
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+function renderBlock() {
+  render(
+    <CodeBlock>
+      <code className="language-tsx">{SNIPPET}</code>
+    </CodeBlock>
+  );
+  return screen.getByRole('button', { name: 'Copy code' });
+}
+
+describe('CodeBlock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText.mockReset().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('copies the block verbatim — imports, trailing newline, no control label', async () => {
+    const copy = renderBlock();
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(writeText).toHaveBeenCalledWith(SNIPPET);
+    expect(writeText.mock.calls[0]![0]).not.toMatch(/copy/i);
+  });
+
+  it('announces the confirmation, then resets it', async () => {
+    const copy = renderBlock();
+
+    expect(screen.getByRole('status').textContent).toBe('');
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(screen.getByRole('status').textContent).toBe(
+      'Code copied to clipboard'
+    );
+    expect(copy.dataset.copyStatus).toBe('copied');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole('status').textContent).toBe('');
+    expect(copy.dataset.copyStatus).toBe('idle');
+  });
+
+  it('announces a failed write instead of leaving a silent no-op', async () => {
+    writeText.mockRejectedValue(new DOMException('denied', 'NotAllowedError'));
+    const copy = renderBlock();
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(screen.getByRole('status').textContent).toBe('Could not copy code');
+    expect(copy.dataset.copyStatus).toBe('failed');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(copy.dataset.copyStatus).toBe('idle');
+  });
+
+  it('exposes the control as a focusable native button', () => {
+    const copy = renderBlock();
+
+    expect(copy.tagName).toBe('BUTTON');
+    expect(copy.hasAttribute('tabindex')).toBe(false);
+
+    copy.focus();
+    expect(document.activeElement).toBe(copy);
+  });
+});

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -41,7 +41,6 @@ export function CodeBlock({
     setStatus(next);
     announce(COPY_STATUS[next].message);
     window.clearTimeout(timerRef.current);
-    // Icon only — the provider owns how long the announcement stays up.
     timerRef.current = window.setTimeout(
       () => setStatus('idle'),
       RESET_DELAY_MS
@@ -68,9 +67,9 @@ export function CodeBlock({
       <pre
         className={cn(PRE_CLASS, className)}
         {...props}
-        // Both below the spread: the props type omits them, but MDX plugins
-        // inject props at runtime where the type cannot reach.
         ref={preRef}
+        // Below the spread: a rehype plugin can set `tabIndex` through
+        // `hProperties`, and the scroll container's own tab stop has to win.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
       >

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -68,8 +68,7 @@ export function CodeBlock({
         className={cn(PRE_CLASS, className)}
         {...props}
         ref={preRef}
-        // Below the spread: an MDX plugin can set `tabIndex`, and the scroll
-        // container's own tab stop has to win.
+        // Below the spread so an injected `tabIndex` cannot replace this one.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
       >

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -10,39 +10,26 @@ import { Button } from './nexus';
 
 const RESET_DELAY_MS = 2000;
 
-type CopyStatus = 'idle' | 'copied' | 'failed';
-
-const COPY_STATUS: Record<
-  CopyStatus,
-  { icon: React.ReactNode; message: string; textClass: string }
-> = {
-  idle: { icon: <IconCopy />, message: '', textClass: '' },
+const COPY_STATUS = {
+  idle: { icon: <IconCopy />, message: '', className: '' },
   copied: {
     icon: <IconCheck />,
     message: 'Code copied to clipboard',
-    textClass: 'nx:text-success-subtle-foreground',
+    className: 'nx:text-success-subtle-foreground',
   },
   failed: {
     icon: <IconX />,
     message: 'Could not copy code',
-    textClass: 'nx:text-error-subtle-foreground',
+    className: 'nx:text-error-subtle-foreground',
   },
 };
+
+type CopyStatus = keyof typeof COPY_STATUS;
 
 const PRE_CLASS =
   'nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:pe-14 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0 nx:[&_code]:typography-code-block';
 
-/**
- * The MDX `<pre>` override. Copy-paste is how Nexus components are adopted, so
- * every fenced block carries a control that yields the whole snippet — imports
- * included — in one click.
- *
- * The control is a sibling of the `<pre>`, not a child: the copied string is
- * read straight off `<pre>.textContent`, so the button's own label can never
- * leak into it, and a hand-selection of the block does not pick it up either.
- * Reading the DOM rather than the React children also keeps the copy exact once
- * syntax highlighting wraps the source in nested spans.
- */
+/** The MDX `<pre>` override: the code block plus a control that copies it. */
 export function CodeBlock({
   children,
   className,
@@ -50,7 +37,7 @@ export function CodeBlock({
 }: React.ComponentProps<'pre'>) {
   const preRef = React.useRef<HTMLPreElement>(null);
   const [status, setStatus] = React.useState<CopyStatus>('idle');
-  const { icon, message, textClass } = COPY_STATUS[status];
+  const { icon, message, className: statusClass } = COPY_STATUS[status];
 
   React.useEffect(() => {
     if (status === 'idle') return;
@@ -60,8 +47,6 @@ export function CodeBlock({
   }, [status]);
 
   const handleCopy = async () => {
-    // textContent, not innerText: it keeps the source verbatim, including the
-    // fence's trailing newline, where innerText would collapse the whitespace.
     const source = preRef.current?.textContent;
     if (!source) return;
 
@@ -79,12 +64,11 @@ export function CodeBlock({
         {children}
       </pre>
       <Button
-        type="button"
         variant="outline"
         size="icon-sm"
         aria-label="Copy code"
         data-copy-status={status}
-        className={join('nx:absolute nx:top-2 nx:end-2', textClass)}
+        className={join('nx:absolute nx:top-2 nx:end-2', statusClass)}
         onClick={handleCopy}
       >
         {icon}

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import * as React from 'react';
+
+import { IconCheck, IconCopy, IconX } from '@tabler/icons-react';
+
+import { join } from '../_lib/class-names';
+
+import { Button } from './nexus';
+
+const RESET_DELAY_MS = 2000;
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+const COPY_STATUS: Record<
+  CopyStatus,
+  { icon: React.ReactNode; message: string; textClass: string }
+> = {
+  idle: { icon: <IconCopy />, message: '', textClass: '' },
+  copied: {
+    icon: <IconCheck />,
+    message: 'Code copied to clipboard',
+    textClass: 'nx:text-success-subtle-foreground',
+  },
+  failed: {
+    icon: <IconX />,
+    message: 'Could not copy code',
+    textClass: 'nx:text-error-subtle-foreground',
+  },
+};
+
+const PRE_CLASS =
+  'nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:pe-14 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0 nx:[&_code]:typography-code-block';
+
+/**
+ * The MDX `<pre>` override. Copy-paste is how Nexus components are adopted, so
+ * every fenced block carries a control that yields the whole snippet — imports
+ * included — in one click.
+ *
+ * The control is a sibling of the `<pre>`, not a child: the copied string is
+ * read straight off `<pre>.textContent`, so the button's own label can never
+ * leak into it, and a hand-selection of the block does not pick it up either.
+ * Reading the DOM rather than the React children also keeps the copy exact once
+ * syntax highlighting wraps the source in nested spans.
+ */
+export function CodeBlock({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'pre'>) {
+  const preRef = React.useRef<HTMLPreElement>(null);
+  const [status, setStatus] = React.useState<CopyStatus>('idle');
+  const { icon, message, textClass } = COPY_STATUS[status];
+
+  React.useEffect(() => {
+    if (status === 'idle') return;
+
+    const timer = window.setTimeout(() => setStatus('idle'), RESET_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
+  const handleCopy = async () => {
+    // textContent, not innerText: it keeps the source verbatim, including the
+    // fence's trailing newline, where innerText would collapse the whitespace.
+    const source = preRef.current?.textContent;
+    if (!source) return;
+
+    try {
+      await navigator.clipboard.writeText(source);
+      setStatus('copied');
+    } catch {
+      setStatus('failed');
+    }
+  };
+
+  return (
+    <div className="nx:relative nx:mb-4">
+      <pre ref={preRef} className={join(PRE_CLASS, className)} {...props}>
+        {children}
+      </pre>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        aria-label="Copy code"
+        data-copy-status={status}
+        className={join('nx:absolute nx:top-2 nx:end-2', textClass)}
+        onClick={handleCopy}
+      >
+        {icon}
+      </Button>
+      <span role="status" className="nx:sr-only">
+        {message}
+      </span>
+    </div>
+  );
+}

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -68,8 +68,8 @@ export function CodeBlock({
         className={cn(PRE_CLASS, className)}
         {...props}
         ref={preRef}
-        // Below the spread: a rehype plugin can set `tabIndex` through
-        // `hProperties`, and the scroll container's own tab stop has to win.
+        // Below the spread: an MDX plugin can set `tabIndex`, and the scroll
+        // container's own tab stop has to win.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
       >

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -11,7 +11,7 @@ import { Button } from './nexus';
 const RESET_DELAY_MS = 2000;
 
 const COPY_STATUS = {
-  idle: { icon: <IconCopy />, message: '' },
+  idle: { icon: <IconCopy /> },
   copied: { icon: <IconCheck />, message: 'Code copied to clipboard' },
   failed: { icon: <IconX />, message: 'Could not copy code' },
 };
@@ -29,7 +29,7 @@ export function CodeBlock({
   children,
   className,
   ...props
-}: React.ComponentProps<'pre'>) {
+}: Omit<React.ComponentProps<'pre'>, 'tabIndex' | 'ref'>) {
   const preRef = React.useRef<HTMLPreElement>(null);
   const timerRef = React.useRef<number | undefined>(undefined);
   const [status, setStatus] = React.useState<CopyStatus>('idle');
@@ -41,10 +41,11 @@ export function CodeBlock({
     setStatus(next);
     announce(COPY_STATUS[next].message);
     window.clearTimeout(timerRef.current);
-    timerRef.current = window.setTimeout(() => {
-      setStatus('idle');
-      announce(COPY_STATUS.idle.message);
-    }, RESET_DELAY_MS);
+    // Icon only — the provider owns how long the announcement stays up.
+    timerRef.current = window.setTimeout(
+      () => setStatus('idle'),
+      RESET_DELAY_MS
+    );
   };
 
   const handleCopy = async () => {
@@ -67,8 +68,8 @@ export function CodeBlock({
       <pre
         className={cn(PRE_CLASS, className)}
         {...props}
-        // Both below the spread: a caller-supplied value must not replace the
-        // ref the copy control reads, nor the scroll container's own tab stop.
+        // Both below the spread: the props type omits them, but MDX plugins
+        // inject props at runtime where the type cannot reach.
         ref={preRef}
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -11,23 +11,18 @@ import { Button } from './nexus';
 const RESET_DELAY_MS = 2000;
 
 const COPY_STATUS = {
-  idle: { icon: <IconCopy />, message: '', className: '' },
-  copied: {
-    icon: <IconCheck />,
-    message: 'Code copied to clipboard',
-    className: 'nx:text-success-subtle-foreground',
-  },
-  failed: {
-    icon: <IconX />,
-    message: 'Could not copy code',
-    className: 'nx:text-error-subtle-foreground',
-  },
+  idle: { icon: <IconCopy />, message: '' },
+  copied: { icon: <IconCheck />, message: 'Code copied to clipboard' },
+  failed: { icon: <IconX />, message: 'Could not copy code' },
 };
 
 type CopyStatus = keyof typeof COPY_STATUS;
 
 const PRE_CLASS =
-  'nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:pe-14 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0 nx:[&_code]:typography-code-block';
+  'nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:pe-14 nx:overflow-x-auto nx:typography-code-block nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_code]:bg-transparent nx:[&_code]:p-0 nx:[&_code]:typography-code-block';
+
+const BUTTON_CLASS =
+  'nx:absolute nx:top-2 nx:end-2 nx:data-[copy-status=copied]:text-success-subtle-foreground nx:data-[copy-status=failed]:text-error-subtle-foreground';
 
 /** The MDX `<pre>` override: the code block plus a control that copies it. */
 export function CodeBlock({
@@ -36,31 +31,52 @@ export function CodeBlock({
   ...props
 }: React.ComponentProps<'pre'>) {
   const preRef = React.useRef<HTMLPreElement>(null);
-  const [status, setStatus] = React.useState<CopyStatus>('idle');
-  const { icon, message, className: statusClass } = COPY_STATUS[status];
+  const timerRef = React.useRef<number | undefined>(undefined);
+  // `seq` advances on every settle so a repeat copy restarts the reset window
+  // and remounts the live-region child — re-rendering the same text would not
+  // announce a second time.
+  const [{ status, seq }, setCopy] = React.useState({
+    status: 'idle' as CopyStatus,
+    seq: 0,
+  });
+  const { icon, message } = COPY_STATUS[status];
 
-  React.useEffect(() => {
-    if (status === 'idle') return;
+  React.useEffect(() => () => window.clearTimeout(timerRef.current), []);
 
-    const timer = window.setTimeout(() => setStatus('idle'), RESET_DELAY_MS);
-    return () => window.clearTimeout(timer);
-  }, [status]);
+  const settle = (next: CopyStatus) => {
+    setCopy((c) => ({ status: next, seq: c.seq + 1 }));
+    window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(
+      () => setCopy((c) => ({ status: 'idle', seq: c.seq + 1 })),
+      RESET_DELAY_MS
+    );
+  };
 
   const handleCopy = async () => {
     const source = preRef.current?.textContent;
-    if (!source) return;
+    if (!source) {
+      settle('failed');
+      return;
+    }
 
     try {
       await navigator.clipboard.writeText(source);
-      setStatus('copied');
+      settle('copied');
     } catch {
-      setStatus('failed');
+      settle('failed');
     }
   };
 
   return (
     <div className="nx:relative nx:mb-4">
-      <pre ref={preRef} className={join(PRE_CLASS, className)} {...props}>
+      <pre
+        ref={preRef}
+        // A scroll container with no focusable children needs its own tab stop.
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+        className={join(PRE_CLASS, className)}
+        {...props}
+      >
         {children}
       </pre>
       <Button
@@ -68,13 +84,13 @@ export function CodeBlock({
         size="icon-sm"
         aria-label="Copy code"
         data-copy-status={status}
-        className={join('nx:absolute nx:top-2 nx:end-2', statusClass)}
+        className={BUTTON_CLASS}
         onClick={handleCopy}
       >
         {icon}
       </Button>
       <span role="status" className="nx:sr-only">
-        {message}
+        <span key={seq}>{message}</span>
       </span>
     </div>
   );

--- a/apps/docs/app/_components/CodeBlock.tsx
+++ b/apps/docs/app/_components/CodeBlock.tsx
@@ -2,10 +2,10 @@
 
 import * as React from 'react';
 
+import { cn } from '@nexus_ds/react/utils';
 import { IconCheck, IconCopy, IconX } from '@tabler/icons-react';
 
-import { join } from '../_lib/class-names';
-
+import { useCopyAnnouncer } from './CopyAnnouncer';
 import { Button } from './nexus';
 
 const RESET_DELAY_MS = 2000;
@@ -32,24 +32,19 @@ export function CodeBlock({
 }: React.ComponentProps<'pre'>) {
   const preRef = React.useRef<HTMLPreElement>(null);
   const timerRef = React.useRef<number | undefined>(undefined);
-  // `seq` advances on every settle so a repeat copy restarts the reset window
-  // and remounts the live-region child — re-rendering the same text would not
-  // announce a second time.
-  const [{ status, seq }, setCopy] = React.useState({
-    status: 'idle' as CopyStatus,
-    seq: 0,
-  });
-  const { icon, message } = COPY_STATUS[status];
+  const [status, setStatus] = React.useState<CopyStatus>('idle');
+  const announce = useCopyAnnouncer();
 
   React.useEffect(() => () => window.clearTimeout(timerRef.current), []);
 
-  const settle = (next: CopyStatus) => {
-    setCopy((c) => ({ status: next, seq: c.seq + 1 }));
+  const settle = (next: Exclude<CopyStatus, 'idle'>) => {
+    setStatus(next);
+    announce(COPY_STATUS[next].message);
     window.clearTimeout(timerRef.current);
-    timerRef.current = window.setTimeout(
-      () => setCopy((c) => ({ status: 'idle', seq: c.seq + 1 })),
-      RESET_DELAY_MS
-    );
+    timerRef.current = window.setTimeout(() => {
+      setStatus('idle');
+      announce(COPY_STATUS.idle.message);
+    }, RESET_DELAY_MS);
   };
 
   const handleCopy = async () => {
@@ -70,12 +65,13 @@ export function CodeBlock({
   return (
     <div className="nx:relative nx:mb-4">
       <pre
+        className={cn(PRE_CLASS, className)}
+        {...props}
+        // Both below the spread: a caller-supplied value must not replace the
+        // ref the copy control reads, nor the scroll container's own tab stop.
         ref={preRef}
-        // A scroll container with no focusable children needs its own tab stop.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        className={join(PRE_CLASS, className)}
-        {...props}
       >
         {children}
       </pre>
@@ -87,11 +83,8 @@ export function CodeBlock({
         className={BUTTON_CLASS}
         onClick={handleCopy}
       >
-        {icon}
+        {COPY_STATUS[status].icon}
       </Button>
-      <span role="status" className="nx:sr-only">
-        <span key={seq}>{message}</span>
-      </span>
     </div>
   );
 }

--- a/apps/docs/app/_components/CopyAnnouncer.tsx
+++ b/apps/docs/app/_components/CopyAnnouncer.tsx
@@ -12,11 +12,6 @@ const CopyAnnouncerContext = React.createContext<
  * The page's single `role="status"` region. Every CodeBlock publishes its copy
  * confirmation here rather than mounting a live region of its own, so a page of
  * twenty fences registers one region with assistive tech instead of twenty.
- *
- * The provider owns how long a message lives. A block that published two
- * seconds ago must not blank the region a sibling has since written to, so the
- * clear timer restarts on every announcement and belongs to the region, not to
- * whichever block spoke last.
  */
 export function CopyAnnouncerProvider({
   children,

--- a/apps/docs/app/_components/CopyAnnouncer.tsx
+++ b/apps/docs/app/_components/CopyAnnouncer.tsx
@@ -8,18 +8,13 @@ const CopyAnnouncerContext = React.createContext<
   ((message: string) => void) | null
 >(null);
 
-/**
- * The page's single `role="status"` region. Every CodeBlock publishes its copy
- * confirmation here rather than mounting a live region of its own, so a page of
- * twenty fences registers one region with assistive tech instead of twenty.
- */
+/** The page's single `role="status"` region for copy confirmations. */
 export function CopyAnnouncerProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // `seq` advances on every announcement so the message child remounts —
-  // re-rendering the same text node would not announce a second time.
+  // `seq` remounts the message node so repeating the same text announces again.
   const [{ message, seq }, setAnnouncement] = React.useState({
     message: '',
     seq: 0,
@@ -28,12 +23,10 @@ export function CopyAnnouncerProvider({
 
   React.useEffect(() => () => window.clearTimeout(timerRef.current), []);
 
-  // Stable so publishing does not re-render every CodeBlock reading the context.
   const announce = React.useCallback((next: string) => {
     setAnnouncement((a) => ({ message: next, seq: a.seq + 1 }));
     window.clearTimeout(timerRef.current);
-    // Blanking without advancing `seq` updates the text node in place, so the
-    // region empties without reading a second time.
+    // Blanking without advancing `seq` empties the region without re-announcing.
     timerRef.current = window.setTimeout(
       () => setAnnouncement((a) => ({ ...a, message: '' })),
       CLEAR_DELAY_MS

--- a/apps/docs/app/_components/CopyAnnouncer.tsx
+++ b/apps/docs/app/_components/CopyAnnouncer.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import * as React from 'react';
+
+const CopyAnnouncerContext = React.createContext<
+  ((message: string) => void) | null
+>(null);
+
+/**
+ * The page's single `role="status"` region. Every CodeBlock publishes its copy
+ * confirmation here rather than mounting a live region of its own, so a page of
+ * twenty fences registers one region with assistive tech instead of twenty.
+ */
+export function CopyAnnouncerProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // `seq` advances on every announcement so the message child remounts —
+  // re-rendering the same text node would not announce a second time.
+  const [{ message, seq }, setAnnouncement] = React.useState({
+    message: '',
+    seq: 0,
+  });
+
+  // Stable so publishing does not re-render every CodeBlock reading the context.
+  const announce = React.useCallback(
+    (next: string) =>
+      setAnnouncement((a) => ({ message: next, seq: a.seq + 1 })),
+    []
+  );
+
+  return (
+    <CopyAnnouncerContext.Provider value={announce}>
+      {children}
+      <span role="status" className="nx:sr-only">
+        <span key={seq}>{message}</span>
+      </span>
+    </CopyAnnouncerContext.Provider>
+  );
+}
+
+export function useCopyAnnouncer() {
+  const announce = React.useContext(CopyAnnouncerContext);
+  if (!announce) {
+    throw new Error(
+      'useCopyAnnouncer must be used inside <CopyAnnouncerProvider>'
+    );
+  }
+  return announce;
+}

--- a/apps/docs/app/_components/CopyAnnouncer.tsx
+++ b/apps/docs/app/_components/CopyAnnouncer.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+const CLEAR_DELAY_MS = 2000;
+
 const CopyAnnouncerContext = React.createContext<
   ((message: string) => void) | null
 >(null);
@@ -10,6 +12,11 @@ const CopyAnnouncerContext = React.createContext<
  * The page's single `role="status"` region. Every CodeBlock publishes its copy
  * confirmation here rather than mounting a live region of its own, so a page of
  * twenty fences registers one region with assistive tech instead of twenty.
+ *
+ * The provider owns how long a message lives. A block that published two
+ * seconds ago must not blank the region a sibling has since written to, so the
+ * clear timer restarts on every announcement and belongs to the region, not to
+ * whichever block spoke last.
  */
 export function CopyAnnouncerProvider({
   children,
@@ -22,13 +29,21 @@ export function CopyAnnouncerProvider({
     message: '',
     seq: 0,
   });
+  const timerRef = React.useRef<number | undefined>(undefined);
+
+  React.useEffect(() => () => window.clearTimeout(timerRef.current), []);
 
   // Stable so publishing does not re-render every CodeBlock reading the context.
-  const announce = React.useCallback(
-    (next: string) =>
-      setAnnouncement((a) => ({ message: next, seq: a.seq + 1 })),
-    []
-  );
+  const announce = React.useCallback((next: string) => {
+    setAnnouncement((a) => ({ message: next, seq: a.seq + 1 }));
+    window.clearTimeout(timerRef.current);
+    // Blanking without advancing `seq` updates the text node in place, so the
+    // region empties without reading a second time.
+    timerRef.current = window.setTimeout(
+      () => setAnnouncement((a) => ({ ...a, message: '' })),
+      CLEAR_DELAY_MS
+    );
+  }, []);
 
   return (
     <CopyAnnouncerContext.Provider value={announce}>

--- a/apps/docs/app/_components/LeftRail.tsx
+++ b/apps/docs/app/_components/LeftRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@nexus_ds/react';
+import { cn } from '@nexus_ds/react/utils';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -21,25 +21,46 @@ import {
   SelectValue,
 } from './nexus';
 
-/** Matches the panel's `bottom-6`; reserved once below it and once above. */
-const PANEL_INSET_PX = 24;
+/**
+ * Below `lg` an expanded panel would reserve roughly half the scrollport, so
+ * it opens collapsed there. `63.99rem` stops just below `lg`'s `min-width:
+ * 64rem`, and staying in rem keeps it aligned with the `nx:lg:` utilities as
+ * the user's base font size changes.
+ */
+const COLLAPSE_QUERY = '(max-width: 63.99rem)';
 
 export function ThemePicker() {
-  const { state, setState } = useNexusAppearance();
-  const [collapsed, setCollapsed] = useState(false);
   const pathname = usePathname();
+
+  // The landing page ships its own in-page theme swapper; the global corner
+  // picker would overlap it and duplicate its controls, so hide it there.
+  if (pathname === '/') return null;
+
+  return <ThemePanel />;
+}
+
+function ThemePanel() {
+  const { state, setState } = useNexusAppearance();
+  const collapsedByDefault = useMediaQuery(COLLAPSE_QUERY);
+  const [collapsedOverride, setCollapsedOverride] = useState<boolean | null>(
+    null
+  );
+  const collapsed = collapsedOverride ?? collapsedByDefault;
   const panelRef = useRef<HTMLElement>(null);
 
   // Publish the panel's real height so `scroll-pb` clears it and Tab never
-  // parks a control underneath (WCAG 2.4.11). Re-runs per route, so the
-  // reservation drops to 0 wherever the panel does not render.
+  // parks a control underneath (WCAG 2.4.11). The reservation stays 0 wherever
+  // no panel mounts.
   useEffect(() => {
     const panel = panelRef.current;
     if (!panel) return;
 
     const root = document.documentElement;
     const observer = new ResizeObserver(() => {
-      const clearance = panel.offsetHeight + PANEL_INSET_PX * 2;
+      const rect = panel.getBoundingClientRect();
+      // `bottom-6` is density-scaled, so measure the gap the panel actually
+      // sits in and reserve it twice — once below the panel, once above it.
+      const clearance = rect.height + (window.innerHeight - rect.bottom) * 2;
       root.style.setProperty('--docs-panel-offset', `${clearance}px`);
     });
     observer.observe(panel);
@@ -48,11 +69,7 @@ export function ThemePicker() {
       observer.disconnect();
       root.style.removeProperty('--docs-panel-offset');
     };
-  }, [pathname]);
-
-  // The landing page ships its own in-page theme swapper; the global corner
-  // picker would overlap it and duplicate its controls, so hide it there.
-  if (pathname === '/') return null;
+  }, []);
 
   const onChange = (mode: ThemeMode) => (value: string) => {
     setState((current) => updateThemeMode(current, mode, value));
@@ -61,11 +78,11 @@ export function ThemePicker() {
   return (
     <aside
       ref={panelRef}
-      className="nx:fixed nx:bottom-6 nx:right-6 nx:z-popover nx:w-[300px] nx:max-h-[calc(100svh-3rem)] nx:overflow-y-auto nx:bg-popover nx:text-popover-foreground nx:border nx:border-border-default nx:rounded-lg nx:shadow-lg"
+      className="nx:fixed nx:bottom-6 nx:right-6 nx:z-popover nx:w-[300px] nx:max-h-[calc(100svh_-_2*var(--nx-spacing-6))] nx:overflow-y-auto nx:bg-popover nx:text-popover-foreground nx:border nx:border-border-default nx:rounded-lg nx:shadow-lg"
     >
       <Button
         variant="ghost"
-        onClick={() => setCollapsed((c) => !c)}
+        onClick={() => setCollapsedOverride(!collapsed)}
         aria-expanded={!collapsed}
         className="nx:w-full nx:justify-between nx:rounded-lg"
       >
@@ -189,4 +206,19 @@ function ModeSelect({
       </SelectContent>
     </Select>
   );
+}
+
+/** Subscribes to a `matchMedia` query, staying in sync as the viewport changes. */
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
 }

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -35,7 +35,7 @@ export function ThemePicker() {
   };
 
   return (
-    <aside className="nx:fixed nx:bottom-6 nx:right-6 nx:z-popover nx:w-[300px] nx:bg-popover nx:text-popover-foreground nx:border nx:border-border-default nx:rounded-lg nx:shadow-lg">
+    <aside className="nx:fixed nx:bottom-6 nx:right-6 nx:z-popover nx:w-[300px] nx:max-h-(--docs-panel-h) nx:overflow-y-auto nx:bg-popover nx:text-popover-foreground nx:border nx:border-border-default nx:rounded-lg nx:shadow-lg">
       <Button
         variant="ghost"
         onClick={() => setCollapsed((c) => !c)}

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { useNexusAppearance } from '@nexus_ds/react/appearance';
+import { cn } from '@nexus_ds/react/utils';
 import { usePathname } from 'next/navigation';
 
 import {
@@ -30,8 +31,7 @@ const EXPAND_QUERY = '(min-width: 64rem)';
 export function ThemePicker() {
   const pathname = usePathname();
 
-  // The landing page ships its own in-page theme swapper; the global corner
-  // picker would overlap it and duplicate its controls, so hide it there.
+  // The landing page ships its own theme swapper, which this would overlap.
   if (pathname === '/') return null;
 
   return <ThemePanel />;
@@ -47,8 +47,7 @@ function ThemePanel() {
   const panelRef = useRef<HTMLElement>(null);
 
   // Publish the panel's real height so `scroll-pb` clears it and Tab never
-  // parks a control underneath (WCAG 2.4.11). The reservation stays 0 wherever
-  // no panel mounts.
+  // parks a control underneath (WCAG 2.4.11).
   useEffect(() => {
     const panel = panelRef.current;
     if (!panel) return;
@@ -56,8 +55,7 @@ function ThemePanel() {
     const root = document.documentElement;
     const observer = new ResizeObserver(() => {
       const rect = panel.getBoundingClientRect();
-      // `bottom-6` is density-scaled, so measure the gap the panel actually
-      // sits in and reserve it twice — once below the panel, once above it.
+      // Reserve the measured bottom gap twice: once below, once above.
       const clearance = rect.height + (window.innerHeight - rect.bottom) * 2;
       root.style.setProperty('--docs-panel-offset', `${clearance}px`);
     });
@@ -86,11 +84,10 @@ function ThemePanel() {
       >
         <span>⚙ Theme</span>
         <span
-          className={
-            expanded
-              ? 'nx:text-muted-foreground nx:transition-transform nx:rotate-180'
-              : 'nx:text-muted-foreground nx:transition-transform'
-          }
+          className={cn(
+            'nx:text-muted-foreground nx:transition-transform',
+            expanded && 'nx:rotate-180'
+          )}
         >
           ▼
         </span>
@@ -206,7 +203,6 @@ function ModeSelect({
   );
 }
 
-/** Subscribes to a `matchMedia` query, staying in sync as the viewport changes. */
 function useMediaQuery(query: string) {
   const [matches, setMatches] = useState(false);
 

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useNexusAppearance } from '@nexus_ds/react/appearance';
 import { usePathname } from 'next/navigation';
@@ -21,10 +21,34 @@ import {
   SelectValue,
 } from './nexus';
 
+/** Matches the panel's `bottom-6`; reserved once below it and once above. */
+const PANEL_INSET_PX = 24;
+
 export function ThemePicker() {
   const { state, setState } = useNexusAppearance();
   const [collapsed, setCollapsed] = useState(false);
   const pathname = usePathname();
+  const panelRef = useRef<HTMLElement>(null);
+
+  // Publish the panel's real height so `scroll-pb` clears it and Tab never
+  // parks a control underneath (WCAG 2.4.11). Re-runs per route, so the
+  // reservation drops to 0 wherever the panel does not render.
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const root = document.documentElement;
+    const observer = new ResizeObserver(() => {
+      const clearance = panel.offsetHeight + PANEL_INSET_PX * 2;
+      root.style.setProperty('--docs-panel-offset', `${clearance}px`);
+    });
+    observer.observe(panel);
+
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty('--docs-panel-offset');
+    };
+  }, [pathname]);
 
   // The landing page ships its own in-page theme swapper; the global corner
   // picker would overlap it and duplicate its controls, so hide it there.
@@ -35,7 +59,10 @@ export function ThemePicker() {
   };
 
   return (
-    <aside className="nx:fixed nx:bottom-6 nx:right-6 nx:z-popover nx:w-[300px] nx:max-h-(--docs-panel-h) nx:overflow-y-auto nx:bg-popover nx:text-popover-foreground nx:border nx:border-border-default nx:rounded-lg nx:shadow-lg">
+    <aside
+      ref={panelRef}
+      className="nx:fixed nx:bottom-6 nx:right-6 nx:z-popover nx:w-[300px] nx:max-h-[calc(100svh-3rem)] nx:overflow-y-auto nx:bg-popover nx:text-popover-foreground nx:border nx:border-border-default nx:rounded-lg nx:shadow-lg"
+    >
       <Button
         variant="ghost"
         onClick={() => setCollapsed((c) => !c)}

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -22,12 +22,14 @@ import {
 } from './nexus';
 
 /**
- * Below `lg` an expanded panel would reserve roughly half the scrollport, so
- * it opens collapsed there. `63.99rem` stops just below `lg`'s `min-width:
- * 64rem`, and staying in rem keeps it aligned with the `nx:lg:` utilities as
- * the user's base font size changes.
+ * Below `lg` an expanded panel would reserve roughly half the scrollport, so it
+ * opens collapsed there. The query asks for the *expanded* case so its
+ * unmatched value — the one the prerendered HTML and the first client render
+ * both use — is the collapsed one, and mobile never paints an expanded panel or
+ * publishes its oversized reservation. Staying in rem keeps the threshold
+ * aligned with the `nx:lg:` utilities as the user's base font size changes.
  */
-const COLLAPSE_QUERY = '(max-width: 63.99rem)';
+const EXPAND_QUERY = '(min-width: 64rem)';
 
 export function ThemePicker() {
   const pathname = usePathname();
@@ -41,11 +43,11 @@ export function ThemePicker() {
 
 function ThemePanel() {
   const { state, setState } = useNexusAppearance();
-  const collapsedByDefault = useMediaQuery(COLLAPSE_QUERY);
-  const [collapsedOverride, setCollapsedOverride] = useState<boolean | null>(
+  const expandedByDefault = useMediaQuery(EXPAND_QUERY);
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(
     null
   );
-  const collapsed = collapsedOverride ?? collapsedByDefault;
+  const expanded = expandedOverride ?? expandedByDefault;
   const panelRef = useRef<HTMLElement>(null);
 
   // Publish the panel's real height so `scroll-pb` clears it and Tab never
@@ -82,22 +84,22 @@ function ThemePanel() {
     >
       <Button
         variant="ghost"
-        onClick={() => setCollapsedOverride(!collapsed)}
-        aria-expanded={!collapsed}
+        onClick={() => setExpandedOverride(!expanded)}
+        aria-expanded={expanded}
         className="nx:w-full nx:justify-between nx:rounded-lg"
       >
         <span>⚙ Theme</span>
         <span
           className={
-            collapsed
-              ? 'nx:text-muted-foreground nx:transition-transform'
-              : 'nx:text-muted-foreground nx:transition-transform nx:rotate-180'
+            expanded
+              ? 'nx:text-muted-foreground nx:transition-transform nx:rotate-180'
+              : 'nx:text-muted-foreground nx:transition-transform'
           }
         >
           ▼
         </span>
       </Button>
-      {!collapsed && (
+      {expanded && (
         <div className="nx:px-4 nx:pb-4 nx:border-t nx:border-border-default">
           <Section title="Colors">
             <Row label="Scheme">

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -22,12 +22,8 @@ import {
 } from './nexus';
 
 /**
- * Below `lg` an expanded panel would reserve roughly half the scrollport, so it
- * opens collapsed there. The query asks for the *expanded* case so its
- * unmatched value — the one the prerendered HTML and the first client render
- * both use — is the collapsed one, and mobile never paints an expanded panel or
- * publishes its oversized reservation. Staying in rem keeps the threshold
- * aligned with the `nx:lg:` utilities as the user's base font size changes.
+ * Asks for the *expanded* case so the unmatched value — the one the prerendered
+ * HTML and the first client render both use — is the collapsed one.
  */
 const EXPAND_QUERY = '(min-width: 64rem)';
 

--- a/apps/docs/app/_components/TopNav.tsx
+++ b/apps/docs/app/_components/TopNav.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { cn } from '@nexus_ds/react';
 import { useNexusAppearance } from '@nexus_ds/react/appearance';
+import { cn } from '@nexus_ds/react/utils';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 

--- a/apps/docs/app/_lib/class-names.ts
+++ b/apps/docs/app/_lib/class-names.ts
@@ -1,3 +1,0 @@
-/** Appends a caller-supplied className to a base class string. */
-export const join = (base: string, incoming?: string) =>
-  incoming ? `${base} ${incoming}` : base;

--- a/apps/docs/app/_lib/class-names.ts
+++ b/apps/docs/app/_lib/class-names.ts
@@ -1,0 +1,3 @@
+/** Appends a caller-supplied className to a base class string. */
+export const join = (base: string, incoming?: string) =>
+  incoming ? `${base} ${incoming}` : base;

--- a/apps/docs/app/_pages/MultiBrand.tsx
+++ b/apps/docs/app/_pages/MultiBrand.tsx
@@ -163,13 +163,13 @@ export function MultiBrand() {
           surface.
         </p>
         <CodeBlock>
-          {`/* loaded after @nexus_ds/tailwind */
+          <code>{`/* loaded after @nexus_ds/tailwind */
 :root {
   --nx-color-primary-background: oklch(0.55 0.2 145); /* your brand */
 }
 
 /* density on a subtree */
-<section data-density="compact"> … compact … </section>`}
+<section data-density="compact"> … compact … </section>`}</code>
         </CodeBlock>
       </section>
 

--- a/apps/docs/app/_pages/MultiBrand.tsx
+++ b/apps/docs/app/_pages/MultiBrand.tsx
@@ -1,4 +1,5 @@
 import { Breadcrumb } from '../_components/Breadcrumb';
+import { CodeBlock } from '../_components/CodeBlock';
 import { Button } from '../_components/nexus';
 
 /**
@@ -161,7 +162,7 @@ export function MultiBrand() {
           does the rest. See <strong>Consumer overrides</strong> for the full
           surface.
         </p>
-        <pre className="nx:typography-code-block nx:rounded-lg nx:border nx:border-border-default nx:bg-muted nx:p-4 nx:overflow-x-auto">
+        <CodeBlock>
           {`/* loaded after @nexus_ds/tailwind */
 :root {
   --nx-color-primary-background: oklch(0.55 0.2 145); /* your brand */
@@ -169,7 +170,7 @@ export function MultiBrand() {
 
 /* density on a subtree */
 <section data-density="compact"> … compact … </section>`}
-        </pre>
+        </CodeBlock>
       </section>
 
       {/* ── For agents ──────────────────────────────────────── */}

--- a/apps/docs/app/_pages/Responsive.tsx
+++ b/apps/docs/app/_pages/Responsive.tsx
@@ -158,7 +158,7 @@ export function Responsive() {
           width.
         </p>
         <CodeBlock>
-          {`// Viewport axis — page-shell decision
+          <code>{`// Viewport axis — page-shell decision
 <Show above="lg">
   <Sidebar />
 </Show>
@@ -166,7 +166,7 @@ export function Responsive() {
 // Container axis — component adapts to its parent
 <Hide containerBelow="md">
   <Actions />
-</Hide>`}
+</Hide>`}</code>
         </CodeBlock>
       </section>
 

--- a/apps/docs/app/_pages/Responsive.tsx
+++ b/apps/docs/app/_pages/Responsive.tsx
@@ -1,4 +1,5 @@
 import { Breadcrumb } from '../_components/Breadcrumb';
+import { CodeBlock } from '../_components/CodeBlock';
 
 /**
  * Foundations → Responsive. Server component — the breakpoint scale, the
@@ -156,7 +157,7 @@ export function Responsive() {
           <code>containerAbove=&quot;md&quot;</code> do not fire at the same
           width.
         </p>
-        <pre className="nx:typography-code-block nx:rounded-lg nx:border nx:border-border-default nx:bg-muted nx:p-4 nx:overflow-x-auto">
+        <CodeBlock>
           {`// Viewport axis — page-shell decision
 <Show above="lg">
   <Sidebar />
@@ -166,7 +167,7 @@ export function Responsive() {
 <Hide containerBelow="md">
   <Actions />
 </Hide>`}
-        </pre>
+        </CodeBlock>
       </section>
 
       {/* ── Which mechanism ─────────────────────────────────── */}

--- a/apps/docs/app/_pages/Typography.tsx
+++ b/apps/docs/app/_pages/Typography.tsx
@@ -183,9 +183,9 @@ export function Typography() {
           in running prose.
         </p>
         <CodeBlock>
-          {`import { Button } from '@nexus_ds/react';
+          <code>{`import { Button } from '@nexus_ds/react';
 
-<Button variant="secondary">Ship it</Button>`}
+<Button variant="secondary">Ship it</Button>`}</code>
         </CodeBlock>
       </section>
 

--- a/apps/docs/app/_pages/Typography.tsx
+++ b/apps/docs/app/_pages/Typography.tsx
@@ -1,4 +1,5 @@
 import { Breadcrumb } from '../_components/Breadcrumb';
+import { CodeBlock } from '../_components/CodeBlock';
 
 /**
  * Foundations → Typography. Server component — a live specimen of the type
@@ -181,11 +182,11 @@ export function Typography() {
           </code>{' '}
           in running prose.
         </p>
-        <pre className="nx:typography-code-block nx:rounded-lg nx:border nx:border-border-default nx:bg-muted nx:p-4 nx:overflow-x-auto">
+        <CodeBlock>
           {`import { Button } from '@nexus_ds/react';
 
 <Button variant="secondary">Ship it</Button>`}
-        </pre>
+        </CodeBlock>
       </section>
 
       {/* ── Families ────────────────────────────────────────── */}

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -17,4 +17,9 @@
 :root {
   --docs-header-h: 3.5rem;
   --docs-scroll-offset: calc(var(--docs-header-h) + 1.5rem);
+  /* Caps the floating theme panel and reserves the matching band at the bottom
+     of the scrollport, so sequential focus never parks a control underneath it
+     (WCAG 2.4.11). One token drives both, so the two cannot drift apart. */
+  --docs-panel-h: 30rem;
+  --docs-panel-offset: calc(var(--docs-panel-h) + 1.5rem);
 }

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -17,8 +17,8 @@
 :root {
   --docs-header-h: 3.5rem;
   --docs-scroll-offset: calc(var(--docs-header-h) + 1.5rem);
-  /* Caps the floating theme panel and reserves the same band at the bottom of
-     the scrollport, so Tab never parks a control underneath it. */
-  --docs-panel-h: 30rem;
-  --docs-panel-offset: calc(var(--docs-panel-h) + 1.5rem);
+  /* Reserves a band at the bottom of the scrollport so Tab never parks a
+     control under the floating theme panel. ThemePicker overwrites this with
+     the panel's measured height; it stays 0 wherever no panel renders. */
+  --docs-panel-offset: 0px;
 }

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -17,9 +17,8 @@
 :root {
   --docs-header-h: 3.5rem;
   --docs-scroll-offset: calc(var(--docs-header-h) + 1.5rem);
-  /* Caps the floating theme panel and reserves the matching band at the bottom
-     of the scrollport, so sequential focus never parks a control underneath it
-     (WCAG 2.4.11). One token drives both, so the two cannot drift apart. */
+  /* Caps the floating theme panel and reserves the same band at the bottom of
+     the scrollport, so Tab never parks a control underneath it. */
   --docs-panel-h: 30rem;
   --docs-panel-offset: calc(var(--docs-panel-h) + 1.5rem);
 }

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -17,8 +17,6 @@
 :root {
   --docs-header-h: 3.5rem;
   --docs-scroll-offset: calc(var(--docs-header-h) + 1.5rem);
-  /* Reserves a band at the bottom of the scrollport so Tab never parks a
-     control under the floating theme panel. ThemePicker overwrites this with
-     the panel's measured height; it stays 0 wherever no panel renders. */
+  /* ThemePicker overwrites this with the panel's measured height. */
   --docs-panel-offset: 0px;
 }

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -50,37 +50,37 @@ export default function RootLayout({
           storageKey={DOCS_APPEARANCE_STORAGE_KEY}
           defaultState={DOCS_APPEARANCE_DEFAULT_STATE}
         >
-          <TopNav />
           <CopyAnnouncerProvider>
+            <TopNav />
             <main>{children}</main>
-          </CopyAnnouncerProvider>
-          <ThemePicker />
-          <footer className="nx:border-t nx:border-border-default nx:mt-16">
-            <div className="nx:max-w-[1280px] nx:mx-auto nx:px-6 nx:py-8 nx:flex nx:flex-col nx:gap-4 nx:sm:flex-row nx:sm:items-center nx:sm:justify-between">
-              <div className="nx:flex nx:items-center nx:gap-3">
-                <span className="nx:font-semibold">Nexus</span>
-                <span className="nx:font-mono nx:text-[11px] nx:text-muted-foreground-subtle">
-                  MIT · v0.0.1
-                </span>
+            <ThemePicker />
+            <footer className="nx:border-t nx:border-border-default nx:mt-16">
+              <div className="nx:max-w-[1280px] nx:mx-auto nx:px-6 nx:py-8 nx:flex nx:flex-col nx:gap-4 nx:sm:flex-row nx:sm:items-center nx:sm:justify-between">
+                <div className="nx:flex nx:items-center nx:gap-3">
+                  <span className="nx:font-semibold">Nexus</span>
+                  <span className="nx:font-mono nx:text-[11px] nx:text-muted-foreground-subtle">
+                    MIT · v0.0.1
+                  </span>
+                </div>
+                <nav className="nx:flex nx:items-center nx:gap-5 nx:typography-label-default nx:text-muted-foreground">
+                  {FOOTER_LINKS.map((link) => {
+                    const isExternal = link.href.startsWith('http');
+                    return (
+                      <a
+                        key={link.label}
+                        href={link.href}
+                        target={isExternal ? '_blank' : undefined}
+                        rel={isExternal ? 'noreferrer' : undefined}
+                        className="nx:rounded-sm nx:hover:text-foreground nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2"
+                      >
+                        {link.label}
+                      </a>
+                    );
+                  })}
+                </nav>
               </div>
-              <nav className="nx:flex nx:items-center nx:gap-5 nx:typography-label-default nx:text-muted-foreground">
-                {FOOTER_LINKS.map((link) => {
-                  const isExternal = link.href.startsWith('http');
-                  return (
-                    <a
-                      key={link.label}
-                      href={link.href}
-                      target={isExternal ? '_blank' : undefined}
-                      rel={isExternal ? 'noreferrer' : undefined}
-                      className="nx:rounded-sm nx:hover:text-foreground nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2"
-                    >
-                      {link.label}
-                    </a>
-                  );
-                })}
-              </nav>
-            </div>
-          </footer>
+            </footer>
+          </CopyAnnouncerProvider>
         </NexusAppearanceProvider>
       </body>
     </html>

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -2,6 +2,7 @@ import { NexusAppearanceProvider } from '@nexus_ds/react/appearance';
 import { NexusAppearanceScript } from '@nexus_ds/react/appearance/server';
 import type { Metadata } from 'next';
 
+import { CopyAnnouncerProvider } from './_components/CopyAnnouncer';
 import { ThemePicker } from './_components/ThemePicker';
 import { TopNav } from './_components/TopNav';
 import {
@@ -50,7 +51,9 @@ export default function RootLayout({
           defaultState={DOCS_APPEARANCE_DEFAULT_STATE}
         >
           <TopNav />
-          <main>{children}</main>
+          <CopyAnnouncerProvider>
+            <main>{children}</main>
+          </CopyAnnouncerProvider>
           <ThemePicker />
           <footer className="nx:border-t nx:border-border-default nx:mt-16">
             <div className="nx:max-w-[1280px] nx:mx-auto nx:px-6 nx:py-8 nx:flex nx:flex-col nx:gap-4 nx:sm:flex-row nx:sm:items-center nx:sm:justify-between">

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className="nx:scroll-pt-(--docs-scroll-offset)"
+      className="nx:scroll-pt-(--docs-scroll-offset) nx:scroll-pb-(--docs-panel-offset)"
       data-density={DOCS_APPEARANCE_DEFAULT_STATE.density}
       data-radius={DOCS_APPEARANCE_DEFAULT_STATE.corners}
       data-shadow={DOCS_APPEARANCE_DEFAULT_STATE.elevation}

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -1,8 +1,8 @@
+import { cn } from '@nexus_ds/react/utils';
 import type { MDXComponents } from 'mdx/types';
 
 import { CodeBlock } from './app/_components/CodeBlock';
 import * as Nexus from './app/_components/nexus';
-import { join } from './app/_lib/class-names';
 
 /**
  * Required by @next/mdx in the App Router. Maps Markdown-rendered HTML to
@@ -20,7 +20,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     // the heading/anchor has content.
     h1: ({ children, className, ...props }) => (
       <h1
-        className={join('nx:typography-heading-large nx:mb-2', className)}
+        className={cn('nx:typography-heading-large nx:mb-2', className)}
         {...props}
       >
         {children}
@@ -28,10 +28,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     h2: ({ children, className, ...props }) => (
       <h2
-        className={join(
-          'nx:typography-heading-small nx:mt-8 nx:mb-3',
-          className
-        )}
+        className={cn('nx:typography-heading-small nx:mt-8 nx:mb-3', className)}
         {...props}
       >
         {children}
@@ -39,7 +36,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     h3: ({ children, className, ...props }) => (
       <h3
-        className={join(
+        className={cn(
           'nx:typography-label-default nx:font-semibold nx:mt-6 nx:mb-2',
           className
         )}
@@ -50,7 +47,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     p: ({ className, ...props }) => (
       <p
-        className={join(
+        className={cn(
           'nx:typography-body-default nx:text-muted-foreground nx:mb-4 nx:max-w-[64ch]',
           className
         )}
@@ -59,7 +56,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     ul: ({ className, ...props }) => (
       <ul
-        className={join(
+        className={cn(
           'nx:list-disc nx:ps-6 nx:mb-4 nx:flex nx:flex-col nx:gap-1 nx:text-muted-foreground',
           className
         )}
@@ -68,7 +65,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     ol: ({ className, ...props }) => (
       <ol
-        className={join(
+        className={cn(
           'nx:list-decimal nx:ps-6 nx:mb-4 nx:flex nx:flex-col nx:gap-1 nx:text-muted-foreground',
           className
         )}
@@ -77,7 +74,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     li: ({ className, ...props }) => (
       <li
-        className={join(
+        className={cn(
           'nx:typography-body-default nx:[&.task-list-item]:list-none nx:[&.task-list-item_input:disabled]:me-2 nx:[&.task-list-item_input:disabled]:align-middle',
           className
         )}
@@ -86,7 +83,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     a: ({ children, className, ...props }) => (
       <a
-        className={join(
+        className={cn(
           'nx:text-primary-subtle-foreground nx:underline nx:underline-offset-2',
           className
         )}
@@ -97,7 +94,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     code: ({ className, ...props }) => (
       <code
-        className={join(
+        className={cn(
           'nx:font-mono nx:typography-code-inline nx:bg-muted nx:px-1 nx:py-0.5 nx:rounded-sm',
           className
         )}
@@ -113,7 +110,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         className="nx:mb-4 nx:overflow-x-auto nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
       >
         <table
-          className={join(
+          className={cn(
             'nx:w-full nx:border-collapse nx:typography-label-default',
             className
           )}
@@ -123,7 +120,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     tr: ({ className, ...props }) => (
       <tr
-        className={join(
+        className={cn(
           'nx:border-b-default nx:border-border-default-alpha nx:[tbody_&:last-child]:border-b-0',
           className
         )}
@@ -135,7 +132,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     th: ({ className, ...props }) => (
       <th
         scope="col"
-        className={join(
+        className={cn(
           'nx:py-2 nx:pe-3 nx:text-start nx:font-semibold nx:text-foreground',
           className
         )}
@@ -144,7 +141,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     td: ({ className, ...props }) => (
       <td
-        className={join(
+        className={cn(
           'nx:py-2 nx:pe-3 nx:align-top nx:text-muted-foreground',
           className
         )}

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -1,9 +1,8 @@
 import type { MDXComponents } from 'mdx/types';
 
+import { CodeBlock } from './app/_components/CodeBlock';
 import * as Nexus from './app/_components/nexus';
-
-const join = (base: string, incoming?: string) =>
-  incoming ? `${base} ${incoming}` : base;
+import { join } from './app/_lib/class-names';
 
 /**
  * Required by @next/mdx in the App Router. Maps Markdown-rendered HTML to
@@ -11,8 +10,9 @@ const join = (base: string, incoming?: string) =>
  * the @nexus_ds/react components so MDX authors can drop a live <Button> etc.
  * into prose with no import.
  *
- * The pre/code pairing matters: a fenced ``` block renders as <pre><code>;
- * the inline-code background is reset inside <pre> so blocks don't double up.
+ * The pre/code pairing matters: a fenced ``` block renders as <pre><code>,
+ * which CodeBlock owns — it keeps the <pre> styling, resets the inline-code
+ * background inside it, and adds the copy control.
  */
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
@@ -104,15 +104,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {...props}
       />
     ),
-    pre: ({ className, ...props }) => (
-      <pre
-        className={join(
-          'nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:mb-4 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0 nx:[&_code]:typography-code-block',
-          className
-        )}
-        {...props}
-      />
-    ),
+    pre: CodeBlock,
     table: ({ className, ...props }) => (
       <div
         // A scroll container with no focusable children needs its own tab stop.

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -9,15 +9,10 @@ import * as Nexus from './app/_components/nexus';
  * Nexus-styled elements (typography utilities, semantic tokens) and exposes
  * the @nexus_ds/react components so MDX authors can drop a live <Button> etc.
  * into prose with no import.
- *
- * The pre/code pairing matters: a fenced ``` block renders as <pre><code>,
- * which CodeBlock owns — it keeps the <pre> styling, resets the inline-code
- * background inside it, and adds the copy control.
  */
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
-    // children rendered explicitly (not via {...props}) so jsx-a11y can see
-    // the heading/anchor has content.
+    // children rendered explicitly so jsx-a11y can see the element has content.
     h1: ({ children, className, ...props }) => (
       <h1
         className={cn('nx:typography-heading-large nx:mb-2', className)}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,6 +19,7 @@
     "@nexus_ds/core": "workspace:*",
     "@nexus_ds/react": "workspace:*",
     "@nexus_ds/tailwind": "workspace:*",
+    "@tabler/icons-react": "^3.36.1",
     "next": "^15.1.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./utils": {
+      "types": "./dist/lib/utils.d.ts",
+      "import": "./dist/utils.mjs",
+      "require": "./dist/utils.js"
+    },
     "./appearance": {
       "types": "./dist/components/appearance/provider/index.d.ts",
       "import": "./dist/appearance.mjs",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,7 +6,6 @@ export {
   CHART_CATEGORICAL_SERIES,
   type ChartCategoricalIndex,
 } from './lib/chart';
-export { cn } from './lib/utils';
 
 // Components
 export * from './components/accordion';

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     lib: {
       entry: {
         index: path.resolve(__dirname, 'src/index.ts'),
+        utils: path.resolve(__dirname, 'src/lib/utils.ts'),
         appearance: path.resolve(
           __dirname,
           'src/components/appearance/provider/index.ts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@nexus_ds/tailwind':
         specifier: workspace:*
         version: link:../../packages/tailwind
+      '@tabler/icons-react':
+        specifier: ^3.36.1
+        version: 3.44.0(react@19.2.7)
       next:
         specifier: ^15.1.6
         version: 15.5.19(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/scripts/verify-export.mjs
+++ b/scripts/verify-export.mjs
@@ -173,10 +173,14 @@ async function smokeImport(producedDir) {
 
   const distDir = path.join(producedDir, 'packages', 'react', 'dist');
   const lib = await import(pathToFileURL(path.join(distDir, 'index.mjs')).href);
+  const utils = await import(pathToFileURL(path.join(distDir, 'utils.mjs')).href);
   const appearance = await import(pathToFileURL(path.join(distDir, 'appearance.mjs')).href);
 
   if (typeof lib.Button !== 'function') {
     throw new Error('Built index.mjs did not export a `Button` component.');
+  }
+  if (typeof utils.cn !== 'function') {
+    throw new Error('Built utils.mjs did not export a `cn` helper.');
   }
   if (typeof appearance.NexusAppearanceProvider !== 'function') {
     throw new Error('Built appearance.mjs did not export `NexusAppearanceProvider`.');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
         replacement: path.resolve(__dirname, './packages/core/src/index.ts'),
       },
       {
+        find: '@nexus_ds/react/utils',
+        replacement: path.resolve(
+          __dirname,
+          './packages/react/src/lib/utils.ts'
+        ),
+      },
+      {
         find: '@nexus_ds/react/appearance/server',
         replacement: path.resolve(
           __dirname,


### PR DESCRIPTION
## Summary

- Replace the MDX `<pre>` override with a `CodeBlock` client component that pairs every fenced block with an icon copy control.
- Copy `<pre>.textContent` **verbatim** — imports and the fence's trailing newline included, nothing trimmed. The control is a *sibling* of the `<pre>`, not a child, so its own label can never land in the copied string (and a hand-selection of the block doesn't pick it up either). Reading the DOM rather than the React children also keeps the copy exact once Shiki (#675) wraps the source in nested spans.
- Confirmation is announced through a `role="status"` region and carried by an icon swap, so it is never conveyed by colour alone; it resets to idle after 2s. A rejected clipboard write reports rather than failing silently.
- Reserve a focus-safe band at the bottom of the scrollport, sized from the theme panel's measured box plus the gap it floats in, so Tab never parks a copy control underneath it (WCAG 2.4.11) — see *Focus obstruction* below.
- Give `@nexus_ds/react` a `./utils` subpath so the server-side `mdx-components.tsx` can reach `cn` without importing the client-only root barrel, and drop `cn` from that barrel so it has one entry point.

## GitHub Issue

Closes #677

## Focus obstruction (WCAG 2.4.11)

The copy control sits at the code block's top-right, which is exactly where the fixed `ThemePicker` panel (`nx:fixed nx:bottom-6 nx:right-6 nx:z-popover`, x 956–1256) overlays the prose column (right edge 1024).

Measured by tabbing through `/getting-started/install` at 1280×900 and hit-testing each focused control:

| | copy controls focused | **entirely** occluded while focused |
| --- | --- | --- |
| Before | 10 | **8** |
| After | 10 | **0** |

The fix follows the shell's existing idiom — the layout already sets `nx:scroll-pt-(--docs-scroll-offset)` on `<html>` so the sticky header can't cover a scroll target. This adds the symmetric `nx:scroll-pb-(--docs-panel-offset)`, which `ThemePanel` fills under a `ResizeObserver` from its own `getBoundingClientRect()`: the panel's height plus **twice** the measured gap beneath it, so the band clears the panel and leaves the same breathing room above it that `bottom-6` leaves below. The reservation therefore tracks the panel it reserves for, and the two cannot drift apart. The panel caps itself at `calc(100svh - 2*var(--nx-spacing-6))` with `overflow-y-auto`, gaining a scrollbar instead of overflowing a short viewport. This fixes the class of bug for every focusable in the docs, not just the copy control.

Because that value feeds the global reservation directly, the panel's default state below `lg` is a layout constraint, not just a preference: an expanded panel at 390×844 publishes roughly half the scrollport as `scroll-pb`. That is why `EXPAND_QUERY` is written as `(min-width: 64rem)` rather than a `max-width` collapse query — its *unmatched* value, the one the prerendered HTML and the first client render both use, is then the collapsed one, so a narrow viewport opens collapsed and never publishes the oversized reservation on first paint. The query governs the default, not a ceiling: tapping the toggle on mobile still expands the panel and still publishes the larger band, which is the correct trade once the user has asked for the panel. Staying in rem keeps the threshold aligned with the `nx:lg:` utilities as the user's base font size changes.

## Design notes

- **Icon-only, always visible.** Copy-paste is the distribution mechanism for Nexus components, not a convenience — so the control does not hide behind hover, which would strand touch and keyboard users.
- **Stable accessible name.** The button stays `aria-label="Copy code"` in every state; the state change is announced once by the live region, rather than twice by also mutating the button's name under a focused screen reader.
- **`textContent`, not `innerText`.** `innerText` would collapse the block's whitespace; `textContent` returns the source byte-for-byte.
- Reached for `@tabler/icons-react` (already the monorepo's icon set, used by `apps/console` and `packages/react/src/lib/icons.ts`) rather than inlining SVGs.

## Test Plan

- [x] `apps/docs/app/_components/CodeBlock.test.tsx` — 10 tests: verbatim copy (imports + trailing newline, no control label), announce-then-idle, failed-write announcement, empty-block reporting, repeat copy, per-block icon isolation, a sibling's confirmation surviving another block's reset, a caller-injected `tabIndex` losing to the scroll container's tab stop, and the focusable native button. 10/10 pass.
- [x] Full unit suite: 662 passed / 1 failed / 55 skipped. The one failure (`scripts/audit-agent-drift.test.js`) and the `generate-tailwind-package` suite error reproduce identically on `main` with these changes stashed — pre-existing and unrelated.
- [x] `pnpm turbo run typecheck` — 7/7 successful.
- [x] `npx eslint . --max-warnings 0` — clean. Prettier clean on all changed files.
- [x] `pnpm --filter @nexus_ds/docs build` — 44/44 static pages; `audit:csp` inventory unchanged in shape.
- [x] Real Chromium (Playwright), light **and** dark: focus ring paints (2px surface gap + 2px outer ring, per `components.md` § Focus States), Enter copies, focus is retained through the state change, status region announces then clears, 0 console errors.
- [x] Focus-obstruction sweep at 1280×900, 1280×600, and 390×844 (mobile reference): panel not clipped, 0 of 10–15 copy controls occluded on focus.
- [x] Verified the button never overlaps code: `pre` carries `nx:pe-14`, button starts 16px clear of the content edge.

**Note on clipboard read-back:** a Playwright `navigator.clipboard.readText()` round-trip returns `"…core\r\n"` for a source of `"…core\n"`. That is the Windows OS clipboard normalising LF→CRLF on read, not a transform in this code — the string handed to `writeText` is pinned byte-for-byte by the unit test.

## Not done

- `#681` (`wldkk/issue-677-add-code-copy-button`) is an earlier open PR against this same issue, currently conflicting with `main`. This PR supersedes it; #681 should be closed if this one lands.
- Browser MCP verification was unavailable on this machine (it points at a hardcoded macOS Brave path — the subject of open PR #685), so the browser evidence above came from Playwright directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

