### PR TITLE
chore(repo): declare docs build outputs in turbo.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,16 @@ jobs:
               - 'README.md'
               - 'AGENTS.md'
               - 'RTK.md'
-            # Root TS config sits outside every package, so turbo's
+            # Root config sits outside every package, so turbo's
             # `--filter=...[base]` selects no tasks for it; the build and
             # typecheck jobs detect it here and run unfiltered instead.
+            # `package.json` carries the `browserslist` that `next build`
+            # resolves upward, and `turbo.json` owns the task graph.
             root_config:
               - 'tsconfig.base.json'
               - 'tsconfig.json'
+              - 'package.json'
+              - 'turbo.json'
             ci:
               - '.github/workflows/**'
 
@@ -204,6 +208,9 @@ jobs:
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-
+
+      - name: Audit turbo output declarations
+        run: pnpm audit:turbo-outputs
 
       - name: Build affected packages
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,8 @@ jobs:
       browser: ${{ steps.filter.outputs.browser }}
       browser_source: ${{ steps.filter.outputs.browser_source }}
       scripts: ${{ steps.filter.outputs.scripts }}
-      # Root-level changes affect every package, so the build and typecheck
-      # jobs run unfiltered rather than resolving to zero tasks. Both read this
-      # single expression so their gates cannot drift apart.
+      # True when the change is root-level, so build and typecheck run
+      # unfiltered instead of resolving to zero tasks.
       build_all: ${{ steps.filter.outputs.ci == 'true' || steps.filter.outputs.root_config == 'true' || steps.filter.outputs.build_scripts == 'true' }}
       # `packages` is true if any package OR any app changed — both are built
       # and typechecked by the shared turbo `build` / `typecheck` jobs.
@@ -73,10 +72,7 @@ jobs:
               - 'AGENTS.md'
               - 'RTK.md'
             # Root config sits outside every package, so turbo's
-            # `--filter=...[base]` selects no tasks for it; the build and
-            # typecheck jobs detect it here and run unfiltered instead.
-            # `package.json` carries the `browserslist` that `next build`
-            # resolves upward, and `turbo.json` owns the task graph.
+            # `--filter=...[base]` selects no tasks for it.
             root_config:
               - 'tsconfig.base.json'
               - 'tsconfig.json'
@@ -85,12 +81,10 @@ jobs:
               - 'pnpm-workspace.yaml'
               - 'pnpm-lock.yaml'
             # Repo-level scripts sit outside every workspace, so no package
-            # filter matches them. `scripts` gates the jobs that lint and
-            # unit-test the whole tree.
+            # filter matches them.
             scripts:
               - 'scripts/**'
-            # The subset the build and typecheck jobs actually execute. These
-            # build unfiltered, so the artifacts typecheck downloads exist.
+            # The subset the build and typecheck jobs execute.
             build_scripts:
               - 'scripts/audit-turbo-outputs.js'
               - 'scripts/typecheck-tailwind-dist.mjs'
@@ -250,8 +244,6 @@ jobs:
           name: build-artifacts
           path: packages/**/dist
           retention-days: 1
-          # Every path into this job builds at least one emitting package, so
-          # an empty upload means the build silently produced nothing.
           if-no-files-found: error
 
   # ============================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,9 @@ jobs:
           name: build-artifacts
           path: packages/**/dist
           retention-days: 1
-          if-no-files-found: warn
+          # Every path into this job builds at least one emitting package, so
+          # an empty upload means the build silently produced nothing.
+          if-no-files-found: error
 
   # ============================================
   # TypeScript Check (affected packages)
@@ -296,14 +298,17 @@ jobs:
       - name: TypeScript check (affected packages)
         env:
           BASE_REF: ${{ github.base_ref }}
+          # Mirrors the build job: root-level changes affect every package, so
+          # they typecheck unfiltered rather than resolving to zero tasks.
+          CHECK_ALL: ${{ needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true' }}
         run: |
-          if [ "${{ needs.changes.outputs.ci }}" = "true" ] || [ "${{ needs.changes.outputs.root_config }}" = "true" ]; then
-            pnpm turbo typecheck
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm turbo typecheck --filter="...[origin/$BASE_REF]"
-          else
-            pnpm turbo typecheck
+          set -euo pipefail
+          filter=()
+          if [ "$CHECK_ALL" != "true" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+            filter=(--filter="...[origin/$BASE_REF]")
           fi
+
+          pnpm turbo typecheck "${filter[@]}"
 
       - name: Core runtime export contract
         run: pnpm --filter @nexus_ds/core audit:runtime-exports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       browser_source: ${{ steps.filter.outputs.browser_source }}
       root_config: ${{ steps.filter.outputs.root_config }}
       scripts: ${{ steps.filter.outputs.scripts }}
+      build_scripts: ${{ steps.filter.outputs.build_scripts }}
       # `packages` is true if any package OR any app changed — both are built
       # and typechecked by the shared turbo `build` / `typecheck` jobs.
       packages: ${{ steps.filter.outputs.packages }}
@@ -82,10 +83,15 @@ jobs:
               - 'pnpm-workspace.yaml'
               - 'pnpm-lock.yaml'
             # Repo-level scripts sit outside every workspace, so no package
-            # filter matches them. They are linted, unit-tested, and run by
-            # the build and typecheck jobs, so gate all four here.
+            # filter matches them. `scripts` gates the jobs that lint and
+            # unit-test the whole tree.
             scripts:
               - 'scripts/**'
+            # The subset the build and typecheck jobs actually execute. These
+            # build unfiltered, so the artifacts typecheck downloads exist.
+            build_scripts:
+              - 'scripts/audit-turbo-outputs.js'
+              - 'scripts/typecheck-tailwind-dist.mjs'
             ci:
               - '.github/workflows/**'
 
@@ -192,7 +198,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.scripts == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -225,23 +231,18 @@ jobs:
       - name: Build affected packages
         env:
           BASE_REF: ${{ github.base_ref }}
-          BUILD_LOG: ${{ runner.temp }}/turbo-build.log
+          # Root-level changes affect every package, so they build unfiltered
+          # and leave a full `dist` set for the typecheck job to download.
+          BUILD_ALL: ${{ needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true' }}
         run: |
           set -euo pipefail
-          if [ "${{ needs.changes.outputs.ci }}" = "true" ] || [ "${{ needs.changes.outputs.root_config }}" = "true" ]; then
-            pnpm turbo build 2>&1 | tee "$BUILD_LOG"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm turbo build --filter="...[origin/$BASE_REF]" 2>&1 | tee "$BUILD_LOG"
-          else
-            pnpm turbo build 2>&1 | tee "$BUILD_LOG"
+          filter=()
+          if [ "$BUILD_ALL" != "true" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+            filter=(--filter="...[origin/$BASE_REF]")
           fi
 
-          # Turbo only warns when a task's declared outputs match nothing, so a
-          # wrong glob caches an empty artifact and the audit above still passes.
-          if grep -q 'no output files found for task' "$BUILD_LOG"; then
-            echo '::error::A build task declared outputs that matched no emitted files. Fix the outputs glob in that package turbo.json.'
-            exit 1
-          fi
+          pnpm turbo build "${filter[@]}"
+          node scripts/audit-turbo-outputs.js --post-build "${filter[@]}"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -259,7 +260,7 @@ jobs:
     name: TypeScript Check
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.scripts == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       browser: ${{ steps.filter.outputs.browser }}
       browser_source: ${{ steps.filter.outputs.browser_source }}
       root_config: ${{ steps.filter.outputs.root_config }}
+      scripts: ${{ steps.filter.outputs.scripts }}
       # `packages` is true if any package OR any app changed — both are built
       # and typechecked by the shared turbo `build` / `typecheck` jobs.
       packages: ${{ steps.filter.outputs.packages }}
@@ -78,6 +79,13 @@ jobs:
               - 'tsconfig.json'
               - 'package.json'
               - 'turbo.json'
+              - 'pnpm-workspace.yaml'
+              - 'pnpm-lock.yaml'
+            # Repo-level scripts sit outside every workspace, so no package
+            # filter matches them. They are linted, unit-tested, and run by
+            # the build and typecheck jobs, so gate all four here.
+            scripts:
+              - 'scripts/**'
             ci:
               - '.github/workflows/**'
 
@@ -91,6 +99,7 @@ jobs:
     if: >-
       needs.changes.outputs.browser_source == 'true' ||
       needs.changes.outputs.browser == 'true' ||
+      needs.changes.outputs.scripts == 'true' ||
       needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
@@ -118,6 +127,7 @@ jobs:
     if: >-
       needs.changes.outputs.browser_source == 'true' ||
       needs.changes.outputs.browser == 'true' ||
+      needs.changes.outputs.scripts == 'true' ||
       needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
@@ -182,7 +192,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.scripts == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -215,13 +225,22 @@ jobs:
       - name: Build affected packages
         env:
           BASE_REF: ${{ github.base_ref }}
+          BUILD_LOG: ${{ runner.temp }}/turbo-build.log
         run: |
+          set -euo pipefail
           if [ "${{ needs.changes.outputs.ci }}" = "true" ] || [ "${{ needs.changes.outputs.root_config }}" = "true" ]; then
-            pnpm turbo build
+            pnpm turbo build 2>&1 | tee "$BUILD_LOG"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm turbo build --filter="...[origin/$BASE_REF]"
+            pnpm turbo build --filter="...[origin/$BASE_REF]" 2>&1 | tee "$BUILD_LOG"
           else
-            pnpm turbo build
+            pnpm turbo build 2>&1 | tee "$BUILD_LOG"
+          fi
+
+          # Turbo only warns when a task's declared outputs match nothing, so a
+          # wrong glob caches an empty artifact and the audit above still passes.
+          if grep -q 'no output files found for task' "$BUILD_LOG"; then
+            echo '::error::A build task declared outputs that matched no emitted files. Fix the outputs glob in that package turbo.json.'
+            exit 1
           fi
 
       - name: Upload build artifacts
@@ -240,7 +259,7 @@ jobs:
     name: TypeScript Check
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.scripts == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -308,6 +327,7 @@ jobs:
     if: >-
       needs.changes.outputs.browser_source == 'true' ||
       needs.changes.outputs.browser == 'true' ||
+      needs.changes.outputs.scripts == 'true' ||
       needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,11 @@ jobs:
       react: ${{ steps.filter.outputs.react }}
       browser: ${{ steps.filter.outputs.browser }}
       browser_source: ${{ steps.filter.outputs.browser_source }}
-      root_config: ${{ steps.filter.outputs.root_config }}
       scripts: ${{ steps.filter.outputs.scripts }}
-      build_scripts: ${{ steps.filter.outputs.build_scripts }}
+      # Root-level changes affect every package, so the build and typecheck
+      # jobs run unfiltered rather than resolving to zero tasks. Both read this
+      # single expression so their gates cannot drift apart.
+      build_all: ${{ steps.filter.outputs.ci == 'true' || steps.filter.outputs.root_config == 'true' || steps.filter.outputs.build_scripts == 'true' }}
       # `packages` is true if any package OR any app changed — both are built
       # and typechecked by the shared turbo `build` / `typecheck` jobs.
       packages: ${{ steps.filter.outputs.packages }}
@@ -198,7 +200,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.build_all == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -231,9 +233,7 @@ jobs:
       - name: Build affected packages
         env:
           BASE_REF: ${{ github.base_ref }}
-          # Root-level changes affect every package, so they build unfiltered
-          # and leave a full `dist` set for the typecheck job to download.
-          BUILD_ALL: ${{ needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true' }}
+          BUILD_ALL: ${{ needs.changes.outputs.build_all }}
         run: |
           set -euo pipefail
           filter=()
@@ -262,7 +262,7 @@ jobs:
     name: TypeScript Check
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.build_all == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -298,13 +298,11 @@ jobs:
       - name: TypeScript check (affected packages)
         env:
           BASE_REF: ${{ github.base_ref }}
-          # Mirrors the build job: root-level changes affect every package, so
-          # they typecheck unfiltered rather than resolving to zero tasks.
-          CHECK_ALL: ${{ needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true' || needs.changes.outputs.build_scripts == 'true' }}
+          BUILD_ALL: ${{ needs.changes.outputs.build_all }}
         run: |
           set -euo pipefail
           filter=()
-          if [ "$CHECK_ALL" != "true" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$BUILD_ALL" != "true" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
             filter=(--filter="...[origin/$BASE_REF]")
           fi
 

--- a/apps/console/turbo.json
+++ b/apps/console/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/apps/console/turbo.json
+++ b/apps/console/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     }
   }

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -4,6 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/package.json"],
       "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
     }
   }

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/package.json"],
       "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
     }

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "tokens:tailwind": "cd packages/core && pnpm build:tailwind && cp dist/tailwind/* ../../packages/tailwind/",
     "audit:browser-support": "node scripts/audit-browser-support.js",
     "audit:agent-drift": "node scripts/audit-agent-drift.js",
+    "audit:turbo-outputs": "node scripts/audit-turbo-outputs.js",
     "audit:contrast": "vitest run --project=unit packages/core/src/lib/derive-theme.test.ts -t \"legibility invariant\"",
     "audit:mode-codenames": "pnpm --filter @nexus_ds/core audit:mode-codenames",
     "audit:mode-distinctness": "pnpm --filter @nexus_ds/core audit:mode-distinctness",

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -8,14 +8,13 @@
         "src/**",
         "tokens/primitives/color.json",
         "tsup.config.ts",
-        "tsconfig.json",
-        "package.json"
+        "tsconfig.json"
       ],
       "outputs": ["dist/runtime/**"]
     },
     "build:tailwind": {
       "dependsOn": ["build"],
-      "inputs": ["scripts/**", "tokens/**", "src/lib/perceptual-grid.json"],
+      "inputs": ["scripts/**", "tokens/**"],
       "outputs": ["dist/tailwind/**"]
     }
   }

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -12,6 +12,11 @@
         "package.json"
       ],
       "outputs": ["dist/runtime/**"]
+    },
+    "build:tailwind": {
+      "dependsOn": ["build"],
+      "inputs": ["scripts/**", "tokens/**", "src/lib/perceptual-grid.json"],
+      "outputs": ["dist/tailwind/**"]
     }
   }
 }

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": [
         "src/**",
         "tokens/primitives/color.json",

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tokens/primitives/color.json",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json"
+      ],
+      "outputs": ["dist/runtime/**"]
+    }
+  }
+}

--- a/packages/react/turbo.json
+++ b/packages/react/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["src/**", "vite.config.ts", "tsconfig.json"],
       "outputs": ["dist/**"]
     }

--- a/packages/react/turbo.json
+++ b/packages/react/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "vite.config.ts", "tsconfig.json", "package.json"],
+      "inputs": ["src/**", "vite.config.ts", "tsconfig.json"],
       "outputs": ["dist/**"]
     }
   }

--- a/packages/test-utils/turbo.json
+++ b/packages/test-utils/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["src/**", "tsup.config.ts", "tsconfig.json"],
       "outputs": ["dist/**"]
     }

--- a/packages/test-utils/turbo.json
+++ b/packages/test-utils/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "tsup.config.ts", "tsconfig.json", "package.json"],
+      "inputs": ["src/**", "tsup.config.ts", "tsconfig.json"],
       "outputs": ["dist/**"]
     }
   }

--- a/packages/test-utils/turbo.json
+++ b/packages/test-utils/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsup.config.ts", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/scripts/audit-turbo-outputs.js
+++ b/scripts/audit-turbo-outputs.js
@@ -1,0 +1,61 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// Turbo reports a task whose package has no matching script with this command
+// string; those packages emit nothing, so they are exempt from the check.
+const NO_SCRIPT_COMMAND = '<NONEXISTENT>';
+
+export function auditTurboOutputs(options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const tasks = options.tasks ?? readBuildTasks(repoRoot);
+  const problems = [];
+
+  for (const task of tasks) {
+    if (task.command === NO_SCRIPT_COMMAND) continue;
+    if (task.resolvedTaskDefinition?.outputs?.length) continue;
+
+    problems.push({
+      code: 'missing-outputs',
+      task: task.taskId,
+      message:
+        'Package has a `build` script but declares no `outputs`. A cache hit ' +
+        'would restore nothing. Add an `outputs` array to the package turbo.json.',
+    });
+  }
+
+  return { ok: problems.length === 0, problems };
+}
+
+function readBuildTasks(repoRoot) {
+  const stdout = execFileSync('npx', ['turbo', 'run', 'build', '--dry=json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    shell: true,
+  });
+
+  return JSON.parse(stdout).tasks ?? [];
+}
+
+function printResult(result) {
+  if (result.ok) {
+    console.log('Turbo outputs audit passed.');
+    return;
+  }
+
+  console.error('Turbo outputs audit failed:');
+
+  for (const item of result.problems) {
+    console.error(`- ${item.code}: ${item.task} — ${item.message}`);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const result = auditTurboOutputs();
+  printResult(result);
+  process.exit(result.ok ? 0 : 1);
+}

--- a/scripts/audit-turbo-outputs.js
+++ b/scripts/audit-turbo-outputs.js
@@ -6,6 +6,10 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 
+// `turbo/bin/turbo` is a node shim that execs the platform binary, so it runs
+// under `process.execPath` without a shell.
+const TURBO_BIN = path.join(REPO_ROOT, 'node_modules', 'turbo', 'bin', 'turbo');
+
 // Turbo reports a task whose package has no matching script with this command
 // string; those packages emit nothing, so they are exempt from the check.
 const NO_SCRIPT_COMMAND = '<NONEXISTENT>';
@@ -40,19 +44,23 @@ export function auditEmittedOutputs(options = {}) {
   for (const task of tasks) {
     if (task.command === NO_SCRIPT_COMMAND) continue;
 
+    const directory = task.directory.split(path.sep).join('/');
+
     for (const glob of task.resolvedTaskDefinition?.outputs ?? []) {
       if (glob.startsWith('!')) continue;
 
-      const target = path.join(repoRoot, task.directory, literalPrefix(glob));
-      if (isPopulated(target)) continue;
+      const checked = [directory, literalPrefix(glob)]
+        .filter(Boolean)
+        .join('/');
+      if (containsFile(path.join(repoRoot, checked))) continue;
 
       problems.push({
         code: 'unmatched-outputs',
         task: task.taskId,
         message:
-          `Declared output \`${glob}\` matched nothing after the build. A cache ` +
-          `hit would restore an empty artifact. Fix the glob in ` +
-          `${task.directory.split(path.sep).join('/')}/turbo.json.`,
+          `Declared output \`${glob}\` emitted no files under \`${checked}\`. ` +
+          `A cache hit would restore an empty artifact. Fix the glob in ` +
+          `${directory}/turbo.json.`,
       });
     }
   }
@@ -69,22 +77,27 @@ function literalPrefix(glob) {
   return (wildcard === -1 ? segments : segments.slice(0, wildcard)).join('/');
 }
 
-function isPopulated(target) {
+function containsFile(target) {
   const stat = fs.statSync(target, { throwIfNoEntry: false });
 
   if (!stat) return false;
   if (!stat.isDirectory()) return true;
 
-  return fs.readdirSync(target).length > 0;
+  return fs
+    .readdirSync(target, { recursive: true, withFileTypes: true })
+    .some((entry) => entry.isFile());
 }
 
 function resolveTasks(options) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
   const turboArgs = options.turboArgs ?? [];
-  const tasks = options.tasks ?? readBuildTasks(turboArgs);
+  const tasks = options.tasks ?? readBuildTasks(repoRoot, turboArgs);
 
-  // A filter can legitimately select nothing; an unfiltered run cannot, so an
-  // empty list there means the payload shape moved and the audit checked nothing.
-  if (!Array.isArray(tasks) || (tasks.length === 0 && turboArgs.length === 0)) {
+  // A `--filter` can legitimately select nothing; an unfiltered run cannot, so
+  // an empty list there means the payload shape moved and nothing was checked.
+  const filtered = turboArgs.some((arg) => arg.startsWith('--filter'));
+
+  if (!Array.isArray(tasks) || (tasks.length === 0 && !filtered)) {
     throw new Error(
       'turbo reported no `build` tasks. The `--dry=json` payload shape has ' +
         'changed, so the audit cannot verify any output declaration.'
@@ -94,15 +107,14 @@ function resolveTasks(options) {
   return tasks;
 }
 
-function readBuildTasks(turboArgs = []) {
+function readBuildTasks(repoRoot, turboArgs) {
   const stdout = execFileSync(
-    'pnpm',
-    ['exec', 'turbo', 'run', 'build', '--dry=json', ...turboArgs],
+    process.execPath,
+    [TURBO_BIN, 'run', 'build', '--dry=json', ...turboArgs],
     {
-      cwd: REPO_ROOT,
+      cwd: repoRoot,
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,
-      shell: true,
     }
   );
 

--- a/scripts/audit-turbo-outputs.js
+++ b/scripts/audit-turbo-outputs.js
@@ -10,8 +10,15 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const NO_SCRIPT_COMMAND = '<NONEXISTENT>';
 
 export function auditTurboOutputs(options = {}) {
-  const repoRoot = options.repoRoot ?? REPO_ROOT;
-  const tasks = options.tasks ?? readBuildTasks(repoRoot);
+  const tasks = options.tasks ?? readBuildTasks();
+
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    throw new Error(
+      'turbo reported no `build` tasks. The `--dry=json` payload shape has ' +
+        'changed, so the audit cannot verify any output declaration.'
+    );
+  }
+
   const problems = [];
 
   for (const task of tasks) {
@@ -30,15 +37,19 @@ export function auditTurboOutputs(options = {}) {
   return { ok: problems.length === 0, problems };
 }
 
-function readBuildTasks(repoRoot) {
-  const stdout = execFileSync('npx', ['turbo', 'run', 'build', '--dry=json'], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    shell: true,
-  });
+function readBuildTasks() {
+  const stdout = execFileSync(
+    'pnpm',
+    ['exec', 'turbo', 'run', 'build', '--dry=json'],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      shell: true,
+    }
+  );
 
-  return JSON.parse(stdout).tasks ?? [];
+  return JSON.parse(stdout).tasks;
 }
 
 function printResult(result) {

--- a/scripts/audit-turbo-outputs.js
+++ b/scripts/audit-turbo-outputs.js
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,16 +10,10 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // string; those packages emit nothing, so they are exempt from the check.
 const NO_SCRIPT_COMMAND = '<NONEXISTENT>';
 
+const WILDCARD = /[*?[\]{}]/;
+
 export function auditTurboOutputs(options = {}) {
-  const tasks = options.tasks ?? readBuildTasks();
-
-  if (!Array.isArray(tasks) || tasks.length === 0) {
-    throw new Error(
-      'turbo reported no `build` tasks. The `--dry=json` payload shape has ' +
-        'changed, so the audit cannot verify any output declaration.'
-    );
-  }
-
+  const tasks = resolveTasks(options);
   const problems = [];
 
   for (const task of tasks) {
@@ -37,10 +32,72 @@ export function auditTurboOutputs(options = {}) {
   return { ok: problems.length === 0, problems };
 }
 
-function readBuildTasks() {
+export function auditEmittedOutputs(options = {}) {
+  const tasks = resolveTasks(options);
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const problems = [];
+
+  for (const task of tasks) {
+    if (task.command === NO_SCRIPT_COMMAND) continue;
+
+    for (const glob of task.resolvedTaskDefinition?.outputs ?? []) {
+      if (glob.startsWith('!')) continue;
+
+      const target = path.join(repoRoot, task.directory, literalPrefix(glob));
+      if (isPopulated(target)) continue;
+
+      problems.push({
+        code: 'unmatched-outputs',
+        task: task.taskId,
+        message:
+          `Declared output \`${glob}\` matched nothing after the build. A cache ` +
+          `hit would restore an empty artifact. Fix the glob in ` +
+          `${task.directory.split(path.sep).join('/')}/turbo.json.`,
+      });
+    }
+  }
+
+  return { ok: problems.length === 0, problems };
+}
+
+// The leading path segments before the first wildcard — the shallowest
+// directory a glob can possibly match under.
+function literalPrefix(glob) {
+  const segments = glob.split('/');
+  const wildcard = segments.findIndex((segment) => WILDCARD.test(segment));
+
+  return (wildcard === -1 ? segments : segments.slice(0, wildcard)).join('/');
+}
+
+function isPopulated(target) {
+  const stat = fs.statSync(target, { throwIfNoEntry: false });
+
+  if (!stat) return false;
+  if (!stat.isDirectory()) return true;
+
+  return fs.readdirSync(target).length > 0;
+}
+
+function resolveTasks(options) {
+  const turboArgs = options.turboArgs ?? [];
+  const tasks = options.tasks ?? readBuildTasks(turboArgs);
+
+  // A filter can legitimately select nothing; an unfiltered run cannot, so an
+  // empty list there means the payload shape moved and the audit checked nothing.
+  if (!Array.isArray(tasks) || (tasks.length === 0 && turboArgs.length === 0)) {
+    throw new Error(
+      'turbo reported no `build` tasks. The `--dry=json` payload shape has ' +
+        'changed, so the audit cannot verify any output declaration.'
+    );
+  }
+
+  return tasks;
+}
+
+function readBuildTasks(turboArgs = []) {
   const stdout = execFileSync(
     'pnpm',
-    ['exec', 'turbo', 'run', 'build', '--dry=json'],
+    ['exec', 'turbo', 'run', 'build', '--dry=json', ...turboArgs],
     {
       cwd: REPO_ROOT,
       encoding: 'utf8',
@@ -52,21 +109,30 @@ function readBuildTasks() {
   return JSON.parse(stdout).tasks;
 }
 
-function printResult(result) {
-  if (result.ok) {
+function printProblems(problems) {
+  if (problems.length === 0) {
     console.log('Turbo outputs audit passed.');
     return;
   }
 
   console.error('Turbo outputs audit failed:');
 
-  for (const item of result.problems) {
+  for (const item of problems) {
     console.error(`- ${item.code}: ${item.task} — ${item.message}`);
   }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const result = auditTurboOutputs();
-  printResult(result);
-  process.exit(result.ok ? 0 : 1);
+  const argv = process.argv.slice(2);
+  const postBuild = argv.includes('--post-build');
+  const turboArgs = argv.filter((arg) => arg !== '--post-build');
+  const tasks = resolveTasks({ turboArgs });
+
+  const problems = [
+    ...auditTurboOutputs({ tasks, turboArgs }).problems,
+    ...(postBuild ? auditEmittedOutputs({ tasks, turboArgs }).problems : []),
+  ];
+
+  printProblems(problems);
+  process.exit(problems.length === 0 ? 0 : 1);
 }

--- a/scripts/audit-turbo-outputs.js
+++ b/scripts/audit-turbo-outputs.js
@@ -1,14 +1,15 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 
-// `turbo/bin/turbo` is a node shim that execs the platform binary, so it runs
-// under `process.execPath` without a shell.
-const TURBO_BIN = path.join(REPO_ROOT, 'node_modules', 'turbo', 'bin', 'turbo');
+// turbo's entry is a node shim that execs the platform binary, so it runs under
+// `process.execPath` without a shell.
+const TURBO_BIN = createRequire(import.meta.url).resolve('turbo');
 
 // Turbo reports a task whose package has no matching script with this command
 // string; those packages emit nothing, so they are exempt from the check.
@@ -49,9 +50,21 @@ export function auditEmittedOutputs(options = {}) {
     for (const glob of task.resolvedTaskDefinition?.outputs ?? []) {
       if (glob.startsWith('!')) continue;
 
-      const checked = [directory, literalPrefix(glob)]
-        .filter(Boolean)
-        .join('/');
+      const prefix = literalPrefix(glob);
+
+      if (!prefix) {
+        problems.push({
+          code: 'unanchored-outputs',
+          task: task.taskId,
+          message:
+            `Declared output \`${glob}\` starts with a wildcard, so this audit ` +
+            `cannot resolve a directory to check. Anchor it under a literal ` +
+            `directory in ${directory}/turbo.json.`,
+        });
+        continue;
+      }
+
+      const checked = `${directory}/${prefix}`;
       if (containsFile(path.join(repoRoot, checked))) continue;
 
       problems.push({

--- a/scripts/audit-turbo-outputs.js
+++ b/scripts/audit-turbo-outputs.js
@@ -7,12 +7,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 
-// turbo's entry is a node shim that execs the platform binary, so it runs under
-// `process.execPath` without a shell.
 const TURBO_BIN = createRequire(import.meta.url).resolve('turbo');
 
-// Turbo reports a task whose package has no matching script with this command
-// string; those packages emit nothing, so they are exempt from the check.
 const NO_SCRIPT_COMMAND = '<NONEXISTENT>';
 
 const WILDCARD = /[*?[\]{}]/;
@@ -81,8 +77,6 @@ export function auditEmittedOutputs(options = {}) {
   return { ok: problems.length === 0, problems };
 }
 
-// The leading path segments before the first wildcard — the shallowest
-// directory a glob can possibly match under.
 function literalPrefix(glob) {
   const segments = glob.split('/');
   const wildcard = segments.findIndex((segment) => WILDCARD.test(segment));
@@ -106,8 +100,6 @@ function resolveTasks(options) {
   const turboArgs = options.turboArgs ?? [];
   const tasks = options.tasks ?? readBuildTasks(repoRoot, turboArgs);
 
-  // A `--filter` can legitimately select nothing; an unfiltered run cannot, so
-  // an empty list there means the payload shape moved and nothing was checked.
   const filtered = turboArgs.some((arg) => arg.startsWith('--filter'));
 
   if (!Array.isArray(tasks) || (tasks.length === 0 && !filtered)) {

--- a/scripts/audit-turbo-outputs.test.js
+++ b/scripts/audit-turbo-outputs.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { auditTurboOutputs } from './audit-turbo-outputs.js';
+
+function task(taskId, { command = 'build', outputs = [] } = {}) {
+  return { taskId, command, resolvedTaskDefinition: { outputs } };
+}
+
+describe('auditTurboOutputs', () => {
+  it('passes when every build-scripted package declares outputs', () => {
+    const result = auditTurboOutputs({
+      tasks: [
+        task('@nexus_ds/core#build', { outputs: ['dist/runtime/**'] }),
+        task('@nexus_ds/docs#build', {
+          outputs: ['.next/**', '!.next/cache/**', 'next-env.d.ts'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.problems).toEqual([]);
+  });
+
+  it('flags a package that has a build script but no outputs', () => {
+    const result = auditTurboOutputs({
+      tasks: [task('@nexus_ds/future#build')],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toMatchObject([
+      { code: 'missing-outputs', task: '@nexus_ds/future#build' },
+    ]);
+  });
+
+  it('exempts packages with no build script', () => {
+    const result = auditTurboOutputs({
+      tasks: [task('@nexus_ds/tailwind#build', { command: '<NONEXISTENT>' })],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports every offending package, not just the first', () => {
+    const result = auditTurboOutputs({
+      tasks: [
+        task('@nexus_ds/a#build'),
+        task('@nexus_ds/b#build', { outputs: ['dist/**'] }),
+        task('@nexus_ds/c#build'),
+      ],
+    });
+
+    expect(result.problems.map((p) => p.task)).toEqual([
+      '@nexus_ds/a#build',
+      '@nexus_ds/c#build',
+    ]);
+  });
+});

--- a/scripts/audit-turbo-outputs.test.js
+++ b/scripts/audit-turbo-outputs.test.js
@@ -7,6 +7,16 @@ function task(taskId, { command = 'build', outputs = [] } = {}) {
 }
 
 describe('auditTurboOutputs', () => {
+  it('passes for the current repository', { timeout: 120_000 }, () => {
+    expect(auditTurboOutputs()).toEqual({ ok: true, problems: [] });
+  });
+
+  it('throws when turbo reports no build tasks', () => {
+    expect(() => auditTurboOutputs({ tasks: [] })).toThrow(
+      /turbo reported no `build` tasks/
+    );
+  });
+
   it('passes when every build-scripted package declares outputs', () => {
     const result = auditTurboOutputs({
       tasks: [

--- a/scripts/audit-turbo-outputs.test.js
+++ b/scripts/audit-turbo-outputs.test.js
@@ -191,6 +191,26 @@ describe('auditEmittedOutputs', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('flags a glob that starts with a wildcard', () => {
+    const repoRoot = makeRepo({ 'packages/core/package.json': '{}\n' });
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/core#build', {
+          directory: 'packages/core',
+          outputs: ['*.tsbuildinfo', '**/*.js'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toMatchObject([
+      { code: 'unanchored-outputs' },
+      { code: 'unanchored-outputs' },
+    ]);
+  });
+
   it('ignores negated globs', () => {
     const repoRoot = makeRepo({ 'apps/docs/.next/BUILD_ID': 'abc\n' });
 

--- a/scripts/audit-turbo-outputs.test.js
+++ b/scripts/audit-turbo-outputs.test.js
@@ -39,10 +39,6 @@ function makeRepo(files) {
 }
 
 describe('auditTurboOutputs', () => {
-  it('passes for the current repository', { timeout: 120_000 }, () => {
-    expect(auditTurboOutputs()).toEqual({ ok: true, problems: [] });
-  });
-
   it('throws when turbo reports no build tasks', () => {
     expect(() => auditTurboOutputs({ tasks: [] })).toThrow(
       /turbo reported no `build` tasks/
@@ -56,6 +52,12 @@ describe('auditTurboOutputs', () => {
     });
 
     expect(result).toEqual({ ok: true, problems: [] });
+  });
+
+  it('still throws on an empty task list when no filter was passed', () => {
+    expect(() =>
+      auditTurboOutputs({ tasks: [], turboArgs: ['--verbosity=2'] })
+    ).toThrow(/turbo reported no `build` tasks/);
   });
 
   it('passes when every build-scripted package declares outputs', () => {
@@ -151,6 +153,25 @@ describe('auditEmittedOutputs', () => {
     expect(result.problems).toMatchObject([
       { code: 'unmatched-outputs', task: '@nexus_ds/test-utils#build' },
     ]);
+  });
+
+  it('flags an output tree that holds only empty directories', () => {
+    const repoRoot = makeRepo({ 'packages/core/package.json': '{}\n' });
+    fs.mkdirSync(path.join(repoRoot, 'packages/core/dist/runtime'), {
+      recursive: true,
+    });
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/core#build', {
+          directory: 'packages/core',
+          outputs: ['dist/**'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(false);
   });
 
   it('flags an output directory that exists but is empty', () => {

--- a/scripts/audit-turbo-outputs.test.js
+++ b/scripts/audit-turbo-outputs.test.js
@@ -1,9 +1,41 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { auditTurboOutputs } from './audit-turbo-outputs.js';
+import {
+  auditEmittedOutputs,
+  auditTurboOutputs,
+} from './audit-turbo-outputs.js';
 
-function task(taskId, { command = 'build', outputs = [] } = {}) {
-  return { taskId, command, resolvedTaskDefinition: { outputs } };
+const tempDirs = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function task(taskId, { command = 'build', outputs = [], directory } = {}) {
+  return {
+    taskId,
+    command,
+    directory: directory ?? taskId.split('#')[0],
+    resolvedTaskDefinition: { outputs },
+  };
+}
+
+function makeRepo(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-turbo-outputs-'));
+  tempDirs.push(dir);
+
+  for (const [file, content] of Object.entries(files)) {
+    const fullPath = path.join(dir, file);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  }
+
+  return dir;
 }
 
 describe('auditTurboOutputs', () => {
@@ -15,6 +47,15 @@ describe('auditTurboOutputs', () => {
     expect(() => auditTurboOutputs({ tasks: [] })).toThrow(
       /turbo reported no `build` tasks/
     );
+  });
+
+  it('accepts an empty task list when a filter selected nothing', () => {
+    const result = auditTurboOutputs({
+      tasks: [],
+      turboArgs: ['--filter=...[origin/main]'],
+    });
+
+    expect(result).toEqual({ ok: true, problems: [] });
   });
 
   it('passes when every build-scripted package declares outputs', () => {
@@ -63,5 +104,108 @@ describe('auditTurboOutputs', () => {
       '@nexus_ds/a#build',
       '@nexus_ds/c#build',
     ]);
+  });
+});
+
+describe('auditEmittedOutputs', () => {
+  it('passes when each declared glob has matching files on disk', () => {
+    const repoRoot = makeRepo({
+      'packages/core/dist/runtime/index.js': 'export {};\n',
+      'apps/docs/.next/BUILD_ID': 'abc\n',
+      'apps/docs/next-env.d.ts': '/// <reference types="next" />\n',
+    });
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/core#build', {
+          directory: 'packages/core',
+          outputs: ['dist/runtime/**'],
+        }),
+        task('@nexus_ds/docs#build', {
+          directory: 'apps/docs',
+          outputs: ['.next/**', '!.next/cache/**', 'next-env.d.ts'],
+        }),
+      ],
+    });
+
+    expect(result).toEqual({ ok: true, problems: [] });
+  });
+
+  it('flags a glob that is deeper than what the build emitted', () => {
+    const repoRoot = makeRepo({
+      'packages/test-utils/dist/index.js': 'export {};\n',
+    });
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/test-utils#build', {
+          directory: 'packages/test-utils',
+          outputs: ['dist/runtime/**'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toMatchObject([
+      { code: 'unmatched-outputs', task: '@nexus_ds/test-utils#build' },
+    ]);
+  });
+
+  it('flags an output directory that exists but is empty', () => {
+    const repoRoot = makeRepo({ 'apps/console/README.md': '# console\n' });
+    fs.mkdirSync(path.join(repoRoot, 'apps/console/dist'));
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/console#build', {
+          directory: 'apps/console',
+          outputs: ['dist/**'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('ignores negated globs', () => {
+    const repoRoot = makeRepo({ 'apps/docs/.next/BUILD_ID': 'abc\n' });
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/docs#build', {
+          directory: 'apps/docs',
+          outputs: ['.next/**', '!.next/cache/**'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('exempts packages with no build script', () => {
+    const repoRoot = makeRepo({ 'packages/tailwind/nexus.css': ':root {}\n' });
+
+    const result = auditEmittedOutputs({
+      repoRoot,
+      tasks: [
+        task('@nexus_ds/tailwind#build', {
+          command: '<NONEXISTENT>',
+          directory: 'packages/tailwind',
+          outputs: ['dist/**'],
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('throws when turbo reports no build tasks', () => {
+    expect(() => auditEmittedOutputs({ tasks: [], repoRoot: '.' })).toThrow(
+      /turbo reported no `build` tasks/
+    );
   });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
       ],
       "outputs": ["dist/runtime/**"]
     },
+    "@nexus_ds/docs#build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
+    },
     "build:tailwind": {
       "dependsOn": ["build"],
       "inputs": ["scripts/**", "tokens/**", "src/lib/perceptual-grid.json"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.base.json"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"]
     },
-    "build:tailwind": {
+    "@nexus_ds/core#build:tailwind": {
       "dependsOn": ["build"],
       "inputs": ["scripts/**", "tokens/**", "src/lib/perceptual-grid.json"],
       "outputs": ["dist/tailwind/**"]

--- a/turbo.json
+++ b/turbo.json
@@ -2,19 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "inputs": [
-        "src/**",
-        "tokens/primitives/color.json",
-        "tsup.config.ts",
-        "tsconfig.json",
-        "package.json"
-      ],
-      "outputs": ["dist/runtime/**"]
-    },
-    "@nexus_ds/docs#build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
+      "dependsOn": ["^build"]
     },
     "build:tailwind": {
       "dependsOn": ["build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,14 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["tsconfig.base.json"],
+  "globalDependencies": ["tsconfig.base.json", "package.json"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"]
-    },
-    "@nexus_ds/core#build:tailwind": {
-      "dependsOn": ["build"],
-      "inputs": ["scripts/**", "tokens/**", "src/lib/perceptual-grid.json"],
-      "outputs": ["dist/tailwind/**"]
     },
     "storybook": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["tsconfig.base.json", "package.json"],
+  "globalDependencies": ["tsconfig.base.json"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Summary

Gives each package its own Turbo build contract, so the docs app can be cached correctly.

The generic root `build` task was tsup-shaped — `inputs` of `src/**` plus tsup/token files, `outputs` of `dist/runtime/**`. Only `@nexus_ds/core` actually matched it; every other package silently inherited a wrong caching contract. Declaring docs outputs on top of that would have cached a stale artifact, so the root task is fixed first.

| Package | Before | After |
| --- | --- | --- |
| `@nexus_ds/core` | correct by coincidence | `packages/core/turbo.json` — the same narrow inputs minus a no-op `package.json` entry, `dist/runtime/**`; also owns `build:tailwind` |
| `@nexus_ds/react` | already had its own config | unchanged, minus a no-op `package.json` input |
| `@nexus_ds/tailwind` | inherited inputs matched **nothing** — CSS edits never busted dependents | default all-files hashing (no config needed) |
| `@nexus_ds/test-utils` | declared `dist/runtime/**`, emits `dist/` | `dist/**` |
| `@nexus_ds/console` | declared `dist/runtime/**`, emits `dist/` | `dist/**` |
| `@nexus_ds/docs` | no usable contract | outputs `.next/**`, `!.next/cache/**`, `next-env.d.ts`; inputs `$TURBO_DEFAULT$` plus `$TURBO_ROOT$/package.json` |

Root `build` now carries only `dependsOn: ["^build"]`. Package-level configs use `extends: ["//"]`, matching the pattern `packages/react/turbo.json` already established.

### Shared root files are now hashed

Two root files feed the builds but sat in no task's input set, so editing either left every build hash unchanged and restored a stale artifact. They differ in reach — one is read by every package, the other by exactly one:

- `tsconfig.base.json` — every package tsconfig extends it, and tsup's `dts` step reads the resolved config. Flipping its `target` moved 0 of 7 build hashes.
- `package.json` — its `browserslist` sets the browser floor. `apps/docs` declares no local one and there is no `.browserslistrc`, so resolution walks up to the root manifest and `next build` uses it for SWC/CSS targets. Turbo folds only the manifest's *dependency fields* into `hashOfExternalDependencies`, not its contents — changing `browserslist` moved 0 of 7 hashes.

Each is now hashed at the narrowest scope that covers its real consumers:

- `tsconfig.base.json` goes in root `globalDependencies` — every workspace tsconfig extends it, so the blast radius *is* the whole graph. Editing it now busts all five real build tasks; before, zero.
- `package.json` is scoped to its one consumer instead, via `inputs: ["$TURBO_DEFAULT$", "$TURBO_ROOT$/package.json"]` in `apps/docs/turbo.json`. `apps/console` builds with Vite + `@tailwindcss/vite`, neither of which reads `browserslist`, so `next build` is the only turbo task that consumes the field. Editing `browserslist` now busts the docs build and nothing else; before, zero of seven.

A global entry would have worked for `package.json` too, but 54 of the last 100 commits edit the root manifest without touching the lockfile — each one would cold-rebuild all seven packages to catch a field that has changed once in repo history.

### `build:tailwind` is core-owned

The task only exists for `@nexus_ds/core`, but it was declared generically at root, so Turbo materialised it on all seven workspace packages — six as `<NONEXISTENT>` commands carrying core's `dist/tailwind/**` output glob. It now lives in `packages/core/turbo.json`, collapsing the graph from 14 tasks to 2. The only caller, `pnpm tokens:tailwind`, runs the package script directly via `cd packages/core`, so no script or CI job changes.

### The stale-cache bug this avoids

`apps/docs/app/globals.css:3` does `@import '@nexus_ds/tailwind'`, so those CSS files compile into the docs output. But `@nexus_ds/tailwind` has no build script, so `^build` resolved it to a phantom task whose inherited `inputs` (`src/**`, `tsup.config.ts`, …) matched nothing in that package. Editing `nexus.css` left the docs hash unchanged (hashes as measured at the time of that first commit; the current baseline has since moved):

```
before fix:  baseline dbaeb5a8… → nexus.css edit → dbaeb5a8…   (unchanged, cache HIT)
after fix:   baseline dbaeb5a8… → nexus.css edit → 0cdd5fad…   (MISS, rebuilds)
```

Before this PR the docs task cached nothing, so the under-hashing was inert. Declaring `.next/**` would have turned it into an actively wrong artifact restore — exactly what #679 warns against.

### Why `next-env.d.ts` is an output

`next build` emits it and it is gitignored, so it belongs in the declared output set. (An earlier revision of this PR justified it by claiming `pnpm typecheck` breaks without it; that does not reproduce — TypeScript ignores a missing non-glob `include` entry, and `.next/types/**/*.ts` is included separately.)

### Why docs inputs are the default plus exactly one root file

`apps/docs` is 49 tracked files across 14 top-level entries. An under-declared input list fails silently by *not* busting the cache, which is the worse failure mode, so the package's own files stay at `$TURBO_DEFAULT$` — the cost is five non-build files (`CHANGELOG.md`, `mdx-options.test.ts`, `app/_lib/appearance-controls.test.ts`, `app/appearance-ssr/page.test.tsx`, `scripts/audit-csp-inventory.mjs`) participating in the hash.

`$TURBO_ROOT$/package.json` is appended to that default rather than replacing it. It is the one file outside the package that `next build` reads and that Turbo would not otherwise hash; naming it here keeps the entry next to its only consumer instead of in the global hash.

### Why libraries and apps declare inputs differently

The split is deliberate, not an oversight. Libraries (`core`, `react`, `test-utils`) use narrow replacing lists because their build has a knowable entry graph — tsup and vite compile from `src/**` and a config file, so a story, unit test, or CHANGELOG edit has no effect on the emitted bundle and should not bust the cache. `packages/react` alone resolves 227 inputs; moving it to `$TURBO_DEFAULT$` would make every `*.stories.tsx` edit rebuild react, then docs and console downstream.

Apps keep `$TURBO_DEFAULT$` because their input surface is implicit and large — `next.config.ts`, `postcss.config.mjs`, `content/**`, MDX plugins, and framework conventions that are easy to under-declare. There, over-hashing is the safe direction; an under-declared entry fails silently by serving a stale `.next`.

### `dependsOn` is inherited, not restated

An earlier revision restated `dependsOn: ["^build"]` in every package config on the belief that array fields replace rather than merge. That rule applies to root `pkg#task` keys, not to package configs using `extends`. Verified on `apps/docs`, which has three real upstream edges: deleting the line leaves `dependencies` and `resolvedTaskDefinition.dependsOn` byte-identical. The five copies are removed so root stays the single owner of the graph edge and cannot drift from it.

### Guardrails

Two gaps this PR's own contract exposed are closed here rather than left for later:

- `.github/workflows/ci.yml` — the `root_config` path filter listed only the two tsconfigs, so a PR touching only root `package.json` skipped the build and typecheck jobs entirely. `package.json` and `turbo.json` are added, so the `$TURBO_ROOT$/package.json` edge declared in `apps/docs/turbo.json` is actually exercised in CI.
- `scripts/audit-turbo-outputs.js` — root `build` intentionally declares no `outputs`, which means a package added later with a `build` script but no `turbo.json` would report a cache hit and restore nothing. The audit resolves the real graph via `--dry=json` and fails if any package with a build script declares none. It runs in the `build` job before the build, and is covered by `scripts/audit-turbo-outputs.test.js`.

### Scope note

#679 says the ticket "touches only `turbo.json`"; this PR touches ten files. Declaring docs outputs without also fixing the transitive input contracts would satisfy the ticket's letter while shipping precisely the broken-artifact failure its Scope section warns about ("an under-declared output is worse than none"). The extra nine are the per-package contracts that make the docs cache trustworthy — four new configs, a cleanup in `packages/react/turbo.json`, and the two guardrails above (`ci.yml`, the audit script, its test, and the `package.json` script entry).

`build:tailwind` sitting outside `build`'s `^build` closure is a real gap but pre-existing and tracked at #66; the generated CSS in `packages/tailwind/` is committed, so `build` is correct today.

## GitHub Issue

Closes #679

## Test Plan

- [x] Full `turbo build` twice: second run `5 cached, 5 total`, `FULL TURBO`.
- [x] Editing a docs source file busts the cache — `content/getting-started/install.mdx`: `7fe2a55b…` → `187b7641…`; returns to baseline on revert.
- [x] Editing `packages/tailwind/nexus.css` busts the docs cache — `7fe2a55b…` → `674b9179…`.
- [x] Editing `tsconfig.base.json` (`target` flip) busts **all five** real build tasks; before `globalDependencies` it moved zero.
- [x] Editing root `package.json` `browserslist` busts **the docs build only** — the other six hashes hold; before the fix it moved zero of seven (verified with `--no-daemon`).
- [x] `build:tailwind` graph collapses 14 tasks → 2, with core's resolved `inputs` (68 files) and `outputs` (`dist/tailwind/**`) unchanged by the move.
- [x] Both perceptual-grid files still bust `build:tailwind` through the `dependsOn: ["build"]` edge — `d10a1205…` → `4f0f7b05…` (`perceptual-grid.json`) and → `7f551253…` (`perceptual-grid-hue.json`), each returning to baseline on revert.
- [x] Dropping the declared `package.json` input from `core`, `test-utils`, and `react` changes nothing — Turbo hashes a package's own `package.json` and `turbo.json` implicitly. Core's input map is 30 files either way, and editing each package's manifest still busts that package's build.
- [x] Restored docs artifact is not missing files — cleaned `.next` + `next-env.d.ts`, rebuilt from cache: identical file set to the fresh build, 0 missing.
- [x] Restored artifact serves — `next start`: `/` 200, `/getting-started/install` 200 (SSG), `/changelog` 200, `/components` 307 → `/components/inputs` 200, `/appearance-ssr` 200 (dynamic), `/_next/static/css/…` 200.
- [x] Corrected outputs actually restore — emptied `apps/console/dist` and `packages/test-utils/dist`, rebuilt: `FULL TURBO`, both repopulated (4 and 12 files). Under `dist/runtime/**` a cache hit left them empty.
- [x] Resolved contracts verified per package via `--dry=json` against a `main` worktree: tailwind inputs 1 → 10, console 111 → 116, core 29 → 30, test-utils 5 → 6, docs 2 → 50. Console's five new entries are `vite.config.ts`, `index.html`, `public/mockServiceWorker.js`, `CHANGELOG.md`, and `turbo.json`.
- [x] `pnpm turbo run typecheck` — 7/7 successful. `pnpm lint` — clean. `prettier --check` on all touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




