### PR TITLE
fix(tooling): chrome-devtools MCP hardcodes a macOS browser path

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,6 @@
 [mcp_servers.chrome-devtools]
 command = "npx"
-args = [
-    "chrome-devtools-mcp@latest",
-    "--executable-path=/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
-]
+args = ["chrome-devtools-mcp@latest"]
 
 [mcp_servers.figma]
 url = "https://mcp.figma.com/mcp"

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
       "command": "npx",
       "args": [
         "chrome-devtools-mcp@latest",
-        "--executable-path=/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+        "--executable-path=${NEXUS_BROWSER_PATH:-/Applications/Brave Browser.app/Contents/MacOS/Brave Browser}"
       ]
     },
     "nexus-docs-mcp": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,8 @@ args = [
 
 Both servers stay registered and expose the same tool set, so the choice is per-session: point the agent at the `chrome-devtools-local` tools. `--isolated` is what lets it run at all — without it both servers launch into `~/.cache/chrome-devtools-mcp/chrome-profile` and whichever starts second fails with `The browser is already running for …`.
 
+That shared profile is also why only one agent drives the browser at a time: neither `.mcp.json` nor `.codex/config.toml` passes `--isolated`, so Claude Code and Codex cannot hold a browser open at once. If you need both, add `--isolated` to whichever you reach for second.
+
 ---
 
 ## Releasing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,11 +319,26 @@ It launches the browser at `$NEXUS_BROWSER_PATH`, defaulting to Brave's macOS lo
 }
 ```
 
-`~/.claude/settings.json` is per-machine, which is what a browser path is — set it once and every checkout picks it up. Use the project-local `.claude/settings.local.json` (gitignored) only to override a single worktree. Restart Claude Code after editing either. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`; Ubuntu snap installs land at `/snap/bin/chromium`.
+`~/.claude/settings.json` is per-machine, which is what a browser path is — set it once and every checkout picks it up. Use the project-local `.claude/settings.local.json` (gitignored) only to override a single worktree. Restart Claude Code after editing either. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`.
 
-A wrong or missing path does not fail at startup — the server connects, then the first browser tool call returns `Browser was not found at the configured executablePath (...)`. Run `claude mcp list` to confirm the value expanded.
+A wrong or missing path does not fail at startup — the server connects, and the first browser tool call returns `Browser was not found at the configured executablePath (...)`. That call is the only real check: `claude mcp list` reports the server healthy either way, and prints the `${…}` template rather than the value it expanded to.
 
-Codex reads `.codex/config.toml`, which has no environment-variable expansion, so it passes no `--executable-path` at all and `chrome-devtools-mcp` falls back to your system Chrome on every platform.
+### Codex
+
+Codex reads `.codex/config.toml`, which has no environment-variable expansion ([openai/codex#2680](https://github.com/openai/codex/issues/2680)), so there is no equivalent of `$NEXUS_BROWSER_PATH` there. It passes no `--executable-path` at all and `chrome-devtools-mcp` falls back to your system Chrome on every platform.
+
+The two configs therefore default to different browsers — Brave under Claude Code on macOS, Chrome under Codex — and that is deliberate: pinning Brave is what keeps macOS contributors' Claude Code setup unchanged, and Codex cannot express the same default without re-introducing the hardcoded path this section exists to remove.
+
+To drive a different browser under Codex, add a second server under its own name to `~/.codex/config.toml` and use that one — a distinct name avoids depending on how Codex ranks project config against user config:
+
+```toml
+[mcp_servers.chrome-devtools-local]
+command = "npx"
+args = [
+    "chrome-devtools-mcp@latest",
+    "--executable-path=/usr/bin/brave-browser",
+]
+```
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,24 @@ The rule that mandates querying it lives in [`.claude/rules/docs-mcp.md`](.claud
 
 ---
 
+## Browser MCP (chrome-devtools)
+
+`.mcp.json` also wires up `chrome-devtools-mcp`, which drives a real Chromium-family browser for screenshots, [`ui-audit`](.agents/skills/ui-audit-guide/SKILL.md), and checking a change in the running app.
+
+It launches the browser at `$NEXUS_BROWSER_PATH`, which defaults to Brave's macOS location — so on macOS there is nothing to set. Elsewhere, point it at your own Chromium-family binary in `.claude/settings.local.json`. That file is gitignored, so `.mcp.json` stays untouched:
+
+```json
+{
+  "env": {
+    "NEXUS_BROWSER_PATH": "C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe"
+  }
+}
+```
+
+Restart Claude Code after editing it. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`.
+
+---
+
 ## Releasing
 
 Releases are driven by [changesets](https://github.com/changesets/changesets) and the [`Release`](.github/workflows/release.yml) workflow. Only the two runtime packages publish to npm; everything else is either internal or copy/own.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,6 +307,8 @@ The rule that mandates querying it lives in [`.claude/rules/docs-mcp.md`](.claud
 
 ## Browser MCP (chrome-devtools)
 
+### Claude Code
+
 `.mcp.json` wires up `chrome-devtools-mcp`, which drives a real Chromium-family browser for screenshots and for checking a change in the running app.
 
 It launches the browser at `$NEXUS_BROWSER_PATH`, defaulting to Brave's macOS location — so a macOS contributor with Brave installed there sets nothing. Everyone else (and macOS contributors who use a different browser) points it at their own binary by adding an `env` block to `~/.claude/settings.json`, alongside whatever keys are already in the file:
@@ -329,7 +331,9 @@ Codex reads `.codex/config.toml`, which has no environment-variable expansion ([
 
 The two configs therefore default to different browsers — Brave under Claude Code on macOS, Chrome under Codex — and that is deliberate: pinning Brave is what keeps macOS contributors' Claude Code setup unchanged, and Codex cannot express the same default without re-introducing the hardcoded path this section exists to remove.
 
-To drive a different browser under Codex, add a second server under its own name to `~/.codex/config.toml` and use that one — a distinct name avoids depending on how Codex ranks project config against user config:
+This is a change for macOS: `.codex/config.toml` used to pin Brave, so Codex now drives system Chrome instead — and nothing at all if Chrome is not installed. Use the override below to put it back on Brave.
+
+To drive a different browser under Codex, add a second server under its own name to `~/.codex/config.toml` — a distinct name avoids depending on how Codex ranks project config against user config:
 
 ```toml
 [mcp_servers.chrome-devtools-local]
@@ -338,6 +342,13 @@ args = [
     "chrome-devtools-mcp@latest",
     "--executable-path=/usr/bin/brave-browser",
 ]
+```
+
+Both servers then load and expose the same tool set, so picking the right one is a per-session choice rather than something the config settles. To take the project server out of the running, park it with the documented `enabled` key — subject to the same untested precedence question as everything else in this section:
+
+```toml
+[mcp_servers.chrome-devtools]
+enabled = false
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ The two configs therefore default to different browsers — Brave under Claude C
 
 This is a change for macOS: `.codex/config.toml` used to pin Brave, so Codex now drives system Chrome instead — and nothing at all if Chrome is not installed. Use the override below to put it back on Brave.
 
-To drive a different browser under Codex, add a second server under its own name to `~/.codex/config.toml` — a distinct name avoids depending on how Codex ranks project config against user config:
+To drive a different browser under Codex, add a second server under its own name to `~/.codex/config.toml`. Codex ranks the project's `.codex/config.toml` above your user config, so redefining `chrome-devtools` there would not take effect — a distinct name sidesteps that ordering entirely:
 
 ```toml
 [mcp_servers.chrome-devtools-local]
@@ -341,15 +341,11 @@ command = "npx"
 args = [
     "chrome-devtools-mcp@latest",
     "--executable-path=/usr/bin/brave-browser",
+    "--isolated",
 ]
 ```
 
-Both servers then load and expose the same tool set, so picking the right one is a per-session choice rather than something the config settles. To take the project server out of the running, park it with the documented `enabled` key — subject to the same untested precedence question as everything else in this section:
-
-```toml
-[mcp_servers.chrome-devtools]
-enabled = false
-```
+Both servers stay registered and expose the same tool set, so the choice is per-session: point the agent at the `chrome-devtools-local` tools. `--isolated` is what lets it run at all — without it both servers launch into `~/.cache/chrome-devtools-mcp/chrome-profile` and whichever starts second fails with `The browser is already running for …`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,7 +347,7 @@ args = [
 
 Both servers stay registered and expose the same tool set, so the choice is per-session: point the agent at the `chrome-devtools-local` tools. `--isolated` is what lets it run at all — without it both servers launch into `~/.cache/chrome-devtools-mcp/chrome-profile` and whichever starts second fails with `The browser is already running for …`.
 
-That shared profile is also why only one agent drives the browser at a time: neither `.mcp.json` nor `.codex/config.toml` passes `--isolated`, so Claude Code and Codex cannot hold a browser open at once. If you need both, add `--isolated` to whichever you reach for second.
+That shared profile is also why only one agent drives the browser at a time: neither `.mcp.json` nor `.codex/config.toml` passes `--isolated`, so Claude Code and Codex cannot hold a browser open at once. To run both, give one of them an isolated server of its own — the Codex block above, or on the Claude Code side `claude mcp add -s local chrome-devtools-local -- npx chrome-devtools-mcp@latest --isolated`, which registers it for you alone rather than in the tracked `.mcp.json`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,11 +307,11 @@ The rule that mandates querying it lives in [`.claude/rules/docs-mcp.md`](.claud
 
 ## Browser MCP (chrome-devtools)
 
+`chrome-devtools-mcp` drives a real Chromium-family browser for screenshots and for checking a change in the running app.
+
 ### Claude Code
 
-`.mcp.json` wires up `chrome-devtools-mcp`, which drives a real Chromium-family browser for screenshots and for checking a change in the running app.
-
-It launches the browser at `$NEXUS_BROWSER_PATH`, defaulting to Brave's macOS location — so a macOS contributor with Brave installed there sets nothing. Everyone else (and macOS contributors who use a different browser) points it at their own binary by adding an `env` block to `~/.claude/settings.json`, alongside whatever keys are already in the file:
+`.mcp.json` launches the browser at `$NEXUS_BROWSER_PATH`, defaulting to Brave's macOS location — so a macOS contributor with Brave installed there sets nothing. Everyone else adds an `env` block to `~/.claude/settings.json`, alongside whatever keys are already in the file:
 
 ```json
 {
@@ -321,19 +321,15 @@ It launches the browser at `$NEXUS_BROWSER_PATH`, defaulting to Brave's macOS lo
 }
 ```
 
-`~/.claude/settings.json` is per-machine, which is what a browser path is — set it once and every checkout picks it up. Use the project-local `.claude/settings.local.json` (gitignored) only to override a single worktree. Restart Claude Code after editing either. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`.
+Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`. That file is per-machine, so every checkout picks it up; use the gitignored `.claude/settings.local.json` to override a single worktree. Restart Claude Code after editing either.
 
-A wrong or missing path does not fail at startup — the server connects, and the first browser tool call returns `Browser was not found at the configured executablePath (...)`. That call is the only real check: `claude mcp list` reports the server healthy either way, and prints the `${…}` template rather than the value it expanded to.
+A wrong path fails lazily — the server connects and `claude mcp list` reports it healthy, but the first browser tool call returns `Browser was not found at the configured executablePath (...)`. That call is the only real check.
 
 ### Codex
 
-Codex reads `.codex/config.toml`, which has no environment-variable expansion ([openai/codex#2680](https://github.com/openai/codex/issues/2680)), so there is no equivalent of `$NEXUS_BROWSER_PATH` there. It passes no `--executable-path` at all and `chrome-devtools-mcp` falls back to your system Chrome on every platform.
+`.codex/config.toml` has no environment-variable expansion ([openai/codex#2680](https://github.com/openai/codex/issues/2680)), so it passes no `--executable-path` and falls back to system Chrome on every platform. It used to pin Brave, so macOS Codex users now get Chrome — or nothing, if Chrome is not installed.
 
-The two configs therefore default to different browsers — Brave under Claude Code on macOS, Chrome under Codex — and that is deliberate: pinning Brave is what keeps macOS contributors' Claude Code setup unchanged, and Codex cannot express the same default without re-introducing the hardcoded path this section exists to remove.
-
-This is a change for macOS: `.codex/config.toml` used to pin Brave, so Codex now drives system Chrome instead — and nothing at all if Chrome is not installed. Use the override below to put it back on Brave.
-
-To drive a different browser under Codex, add a second server under its own name to `~/.codex/config.toml`. Codex ranks the project's `.codex/config.toml` above your user config, so redefining `chrome-devtools` there would not take effect — a distinct name sidesteps that ordering entirely:
+To pick your own browser, add a second server under its own name to `~/.codex/config.toml`. Codex ranks the project's `.codex/config.toml` above your user config, so redefining `chrome-devtools` there would not take effect:
 
 ```toml
 [mcp_servers.chrome-devtools-local]
@@ -345,9 +341,7 @@ args = [
 ]
 ```
 
-Both servers stay registered and expose the same tool set, so the choice is per-session: point the agent at the `chrome-devtools-local` tools. `--isolated` is what lets it run at all — without it both servers launch into `~/.cache/chrome-devtools-mcp/chrome-profile` and whichever starts second fails with `The browser is already running for …`.
-
-That shared profile is also why only one agent drives the browser at a time: neither `.mcp.json` nor `.codex/config.toml` passes `--isolated`, so Claude Code and Codex cannot hold a browser open at once. To run both, give one of them an isolated server of its own — the Codex block above, or on the Claude Code side `claude mcp add -s local chrome-devtools-local -- npx chrome-devtools-mcp@latest --isolated`, which registers it for you alone rather than in the tracked `.mcp.json`.
+Both servers stay registered with the same tools, so point the agent at the `chrome-devtools-local` ones. `--isolated` is what lets it run: without it every server launches into `~/.cache/chrome-devtools-mcp/chrome-profile` and whichever starts second fails with `The browser is already running for …`. That shared profile is also why Claude Code and Codex cannot hold a browser open at once — to run both, give one an isolated server of its own, either the block above or `claude mcp add -s local chrome-devtools-local -- npx chrome-devtools-mcp@latest --isolated`, which stays out of the tracked `.mcp.json`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,7 +321,7 @@ The rule that mandates querying it lives in [`.claude/rules/docs-mcp.md`](.claud
 }
 ```
 
-Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`. That file is per-machine, so every checkout picks it up; use the gitignored `.claude/settings.local.json` to override a single worktree. Restart Claude Code after editing either.
+`~/.claude/settings.json` is per-machine, so every checkout picks it up; use the gitignored `.claude/settings.local.json` to override a single worktree. Restart Claude Code after editing either. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`.
 
 A wrong path fails lazily — the server connects and `claude mcp list` reports it healthy, but the first browser tool call returns `Browser was not found at the configured executablePath (...)`. That call is the only real check.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,9 +307,9 @@ The rule that mandates querying it lives in [`.claude/rules/docs-mcp.md`](.claud
 
 ## Browser MCP (chrome-devtools)
 
-`.mcp.json` also wires up `chrome-devtools-mcp`, which drives a real Chromium-family browser for screenshots, [`ui-audit`](.agents/skills/ui-audit-guide/SKILL.md), and checking a change in the running app.
+`.mcp.json` wires up `chrome-devtools-mcp`, which drives a real Chromium-family browser for screenshots and for checking a change in the running app.
 
-It launches the browser at `$NEXUS_BROWSER_PATH`, which defaults to Brave's macOS location — so on macOS there is nothing to set. Elsewhere, point it at your own Chromium-family binary in `.claude/settings.local.json`. That file is gitignored, so `.mcp.json` stays untouched:
+It launches the browser at `$NEXUS_BROWSER_PATH`, defaulting to Brave's macOS location — so a macOS contributor with Brave installed there sets nothing. Everyone else (and macOS contributors who use a different browser) points it at their own binary by adding an `env` block to `~/.claude/settings.json`, alongside whatever keys are already in the file:
 
 ```json
 {
@@ -319,7 +319,11 @@ It launches the browser at `$NEXUS_BROWSER_PATH`, which defaults to Brave's macO
 }
 ```
 
-Restart Claude Code after editing it. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`.
+`~/.claude/settings.json` is per-machine, which is what a browser path is — set it once and every checkout picks it up. Use the project-local `.claude/settings.local.json` (gitignored) only to override a single worktree. Restart Claude Code after editing either. Typical Linux paths: `/usr/bin/brave-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`; Ubuntu snap installs land at `/snap/bin/chromium`.
+
+A wrong or missing path does not fail at startup — the server connects, then the first browser tool call returns `Browser was not found at the configured executablePath (...)`. Run `claude mcp list` to confirm the value expanded.
+
+Codex reads `.codex/config.toml`, which has no environment-variable expansion, so it passes no `--executable-path` at all and `chrome-devtools-mcp` falls back to your system Chrome on every platform.
 
 ---
 


### PR DESCRIPTION
## Summary

- `.mcp.json` now resolves the `chrome-devtools-mcp` executable path from `$NEXUS_BROWSER_PATH`, with the current macOS Brave path as the `${VAR:-default}` fallback — so macOS contributors need no change, and everyone else sets one env var.
- The override lives in `.claude/settings.local.json`, which is already gitignored (`.gitignore:45`), so no contributor edits a checked-in file.
- Documented as a new "Browser MCP (chrome-devtools)" section in `CONTRIBUTING.md`, directly after the docs-MCP section.

## GitHub Issue

Closes #684

## Test Plan

- [x] `.mcp.json` still parses; the arg reads `--executable-path=${NEXUS_BROWSER_PATH:-/Applications/Brave Browser.app/Contents/MacOS/Brave Browser}`
- [x] `npx prettier --check .mcp.json CONTRIBUTING.md` passes
- [x] With `NEXUS_BROWSER_PATH` set in `.claude/settings.local.json` on Windows, the variable reaches the tool environment and the target binary exists
- [ ] macOS contributor with Brave installed and no `NEXUS_BROWSER_PATH` set: browser tools still launch (default branch of the expansion)